### PR TITLE
Turn off precompiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIFF_TAG=$(shell git rev-list --tags="v*" --max-count=1 --not $(shell git rev-li
 DEFAULT_TAG=$(shell git rev-list --tags="v*" --max-count=1)
 # VERSION ?= $(shell echo $(shell git describe --tags $(or $(DIFF_TAG), $(DEFAULT_TAG))) | sed 's/^v//')
 
-VERSION := "1.8.2"
+VERSION := "1.8.3"
 CBFTVERSION := $(shell go list -m github.com/cometbft/cometbft | sed 's:.* ::')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true

--- a/app/app.go
+++ b/app/app.go
@@ -176,6 +176,7 @@ import (
 	v180 "github.com/haqq-network/haqq/app/upgrades/v1.8.0"
 	v181 "github.com/haqq-network/haqq/app/upgrades/v1.8.1"
 	v182 "github.com/haqq-network/haqq/app/upgrades/v1.8.2"
+	v183 "github.com/haqq-network/haqq/app/upgrades/v1.8.3"
 
 	// NOTE: override ICS20 keeper to support IBC transfers of ERC20 tokens
 	"github.com/haqq-network/haqq/x/ibc/transfer"
@@ -568,13 +569,13 @@ func NewHaqq(
 	epochsKeeper := epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
 	app.EpochsKeeper = *epochsKeeper.SetHooks(
 		epochskeeper.NewMultiEpochHooks(
-		// insert epoch hooks receivers here
+			// insert epoch hooks receivers here
 		),
 	)
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-		// insert gov hooks receivers here
+			// insert gov hooks receivers here
 		),
 	)
 
@@ -660,7 +661,7 @@ func NewHaqq(
 	transferStack = packetforward.NewIBCMiddleware(
 		transferStack,
 		app.PacketForwardKeeper,
-		0, // retries on timeout
+		0,                                                                // retries on timeout
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
 		packetforwardkeeper.DefaultRefundTransferPacketTimeoutTimestamp,  // refund timeout
 	)
@@ -1293,6 +1294,12 @@ func (app *Haqq) setupUpgradeHandlers(keys map[string]*storetypes.KVStoreKey) {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v182.UpgradeName,
 		v182.CreateUpgradeHandler(app.mm, app.configurator),
+	)
+
+	// v1.8.3 Security upgrade
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v183.UpgradeName,
+		v183.CreateUpgradeHandler(app.mm, app.configurator),
 	)
 
 	// When a planned update height is reached, the old binary will panic

--- a/app/upgrades/v1.8.3/constants.go
+++ b/app/upgrades/v1.8.3/constants.go
@@ -1,0 +1,6 @@
+package v183
+
+const (
+	// UpgradeName is the shared upgrade plan name for mainnet
+	UpgradeName = "v1.8.3"
+)

--- a/app/upgrades/v1.8.3/upgrades.go
+++ b/app/upgrades/v1.8.3/upgrades.go
@@ -1,0 +1,20 @@
+package v183
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v1.8.3
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger()
+		logger.Info("run migration v1.8.3")
+
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -320,7 +320,10 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 
 	// set the custom precompiles to the EVM (if any)
 	if cfg.Params.HasCustomPrecompiles() {
-		customPrecompiles := cfg.Params.GetActivePrecompilesAddrs()
+		// Temporary turn down custom precompiles due to critical security issue
+		// Read: https://github.com/cosmos/evm/security/advisories/GHSA-mjfq-3qr2-6g84
+		// customPrecompiles := cfg.Params.GetActivePrecompilesAddrs()
+		customPrecompiles := make([]common.Address, 0)
 
 		activePrecompiles := make([]common.Address, len(vm.PrecompiledAddressesBerlin)+len(customPrecompiles))
 		copy(activePrecompiles[:len(vm.PrecompiledAddressesBerlin)], vm.PrecompiledAddressesBerlin)


### PR DESCRIPTION
# Temporarily disable precompiles on HAQQ network due to security vulnerability
## Description

This PR disables all precompiles on the HAQQ network to mitigate a recently discovered vulnerability identified by the Interchain team.

Since our current evmOS version is too outdated to apply the recommended fix, we have decided to temporarily disable precompiles entirely as a precautionary measure.

⚠️ Note: Some automated tests are failing due to the disabled precompiles. We are aware of this and consider it acceptable for this temporary patch.

This is a temporary update — we are planning to upgrade the evmOS version as soon as possible to properly patch the vulnerability.

More information:
https://github.com/cosmos/evm/security/advisories/GHSA-mjfq-3qr2-6g84
