### PR TITLE
Fix golang version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,7 +519,7 @@ proto-check-breaking:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/haqq-network/haqq
-GOLANG_CROSS_VERSION  = v1.23
+GOLANG_CROSS_VERSION  = v1.24
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \


### PR DESCRIPTION
Closes: #XXX

## Description
This PR aligns the Go version used by release tooling with the project Go version declared in `go.mod`.
### What changed
- Updated `GOLANG_CROSS_VERSION` in `Makefile` from `v1.23` to `v1.24`.
### Why
- `go.mod` declares `go 1.24.10`, while release targets (`release`, `release-dry-run`) were using `goreleaser-cross:v1.23`.
- This mismatch can cause non-reproducible release builds and toolchain-related inconsistencies.
### Critical files to review
- `Makefile` (release section, `GOLANG_CROSS_VERSION`)
### Validation
- Verified that release targets use `ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION}` and now resolve to Go 1.24 toolchain.


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
