### PR TITLE
Tests/improve coverage of liquid precompile

### DIFF
--- a/precompiles/liquid/events_test.go
+++ b/precompiles/liquid/events_test.go
@@ -1,0 +1,162 @@
+package liquid_test
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	cmn "github.com/haqq-network/haqq/precompiles/common"
+	"github.com/haqq-network/haqq/precompiles/liquid"
+	utiltx "github.com/haqq-network/haqq/testutil/tx"
+	liquidtypes "github.com/haqq-network/haqq/x/liquidvesting/types"
+)
+
+// maxUint256 returns 2^256 - 1, the largest value representable by a uint256.
+func maxUint256() *big.Int {
+	return new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+}
+
+// TestEmitLiquidateEvent verifies that the Liquidate event is emitted with
+// the expected address, signature topic, block number and ABI-encoded payload.
+//
+// Note: zero-amount is not covered here on purpose. MsgLiquidate.ValidateBasic
+// rejects zero coins before EmitLiquidateEvent is ever reached, so the path is
+// unreachable in production.
+func (s *PrecompileTestSuite) TestEmitLiquidateEvent() {
+	testcases := []struct {
+		name          string
+		sender        common.Address
+		receiver      common.Address
+		erc20Contract common.Address
+		amount        *big.Int
+	}{
+		{
+			name:          "pass",
+			sender:        utiltx.GenerateAddress(),
+			receiver:      utiltx.GenerateAddress(),
+			erc20Contract: utiltx.GenerateAddress(),
+			amount:        big.NewInt(1_000_000),
+		},
+		{
+			// Edge case: full uint256 range. Confirms ABI encoding/decoding
+			// round-trips the boundary value without truncation or sign issues.
+			name:          "pass - max uint256 amount",
+			sender:        utiltx.GenerateAddress(),
+			receiver:      utiltx.GenerateAddress(),
+			erc20Contract: utiltx.GenerateAddress(),
+			amount:        maxUint256(),
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			ctx := s.network.GetContext()
+			stateDB := s.network.GetStateDB()
+
+			err := s.precompile.EmitLiquidateEvent(
+				ctx, stateDB, tc.sender, tc.receiver, tc.erc20Contract, tc.amount,
+			)
+			s.Require().NoError(err, "expected liquidate event to be emitted successfully")
+
+			logs := stateDB.Logs()
+			s.Require().Len(logs, 1, "expected exactly one log to be emitted")
+			log := logs[0]
+
+			s.Require().Equal(s.precompile.Address(), log.Address)
+
+			event := s.precompile.ABI.Events[liquid.EventTypeLiquidate]
+			s.Require().Equal(
+				crypto.Keccak256Hash([]byte(event.Sig)),
+				common.HexToHash(log.Topics[0].Hex()),
+				"expected event signature to match",
+			)
+			//nolint: gosec // G115 blockHeight is positive int64 and can't overflow uint64
+			s.Require().Equal(uint64(ctx.BlockHeight()), log.BlockNumber)
+
+			// The Liquidate event has 2 indexed args (sender, receiver), so we
+			// expect 1 (signature) + 2 (indexed) = 3 topics.
+			s.Require().Len(log.Topics, 3, "expected 3 topics")
+
+			var liquidateEvent liquid.EventLiquidate
+			err = cmn.UnpackLog(s.precompile.ABI, &liquidateEvent, liquid.EventTypeLiquidate, *log)
+			s.Require().NoError(err, "unable to unpack log into liquidate event")
+
+			s.Require().Equal(tc.sender, liquidateEvent.Sender, "expected different sender address")
+			s.Require().Equal(tc.receiver, liquidateEvent.Receiver, "expected different receiver address")
+			s.Require().Equal(tc.amount, liquidateEvent.Amount, "expected different amount")
+			s.Require().Equal(tc.erc20Contract, liquidateEvent.Erc20Contract, "expected different erc20 contract address")
+		})
+	}
+}
+
+// TestEmitRedeemEvent verifies that the Redeem event is emitted with the
+// expected address, signature topic, block number and ABI-encoded payload.
+func (s *PrecompileTestSuite) TestEmitRedeemEvent() {
+	testcases := []struct {
+		name     string
+		sender   common.Address
+		receiver common.Address
+		denom    string
+		amount   *big.Int
+	}{
+		{
+			name:     "pass",
+			sender:   utiltx.GenerateAddress(),
+			receiver: utiltx.GenerateAddress(),
+			denom:    liquidtypes.DenomBaseNameFromID(0),
+			amount:   big.NewInt(1_000_000),
+		},
+		{
+			name:     "pass - long denom id",
+			sender:   utiltx.GenerateAddress(),
+			receiver: utiltx.GenerateAddress(),
+			denom:    liquidtypes.DenomBaseNameFromID(42),
+			amount:   big.NewInt(123_456_789),
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			ctx := s.network.GetContext()
+			stateDB := s.network.GetStateDB()
+
+			err := s.precompile.EmitRedeemEvent(
+				ctx, stateDB, tc.sender, tc.receiver, tc.denom, tc.amount,
+			)
+			s.Require().NoError(err, "expected redeem event to be emitted successfully")
+
+			logs := stateDB.Logs()
+			s.Require().Len(logs, 1, "expected exactly one log to be emitted")
+			log := logs[0]
+
+			s.Require().Equal(s.precompile.Address(), log.Address)
+
+			event := s.precompile.ABI.Events[liquid.EventTypeRedeem]
+			s.Require().Equal(
+				crypto.Keccak256Hash([]byte(event.Sig)),
+				common.HexToHash(log.Topics[0].Hex()),
+				"expected event signature to match",
+			)
+			//nolint: gosec // G115 blockHeight is positive int64 and can't overflow uint64
+			s.Require().Equal(uint64(ctx.BlockHeight()), log.BlockNumber)
+
+			// The Redeem event has 2 indexed args (sender, receiver), so we
+			// expect 1 (signature) + 2 (indexed) = 3 topics.
+			s.Require().Len(log.Topics, 3, "expected 3 topics")
+
+			var redeemEvent liquid.EventRedeem
+			err = cmn.UnpackLog(s.precompile.ABI, &redeemEvent, liquid.EventTypeRedeem, *log)
+			s.Require().NoError(err, "unable to unpack log into redeem event")
+
+			s.Require().Equal(tc.sender, redeemEvent.Sender, "expected different sender address")
+			s.Require().Equal(tc.receiver, redeemEvent.Receiver, "expected different receiver address")
+			s.Require().Equal(tc.denom, redeemEvent.Denom, "expected different denom")
+			s.Require().Equal(tc.amount, redeemEvent.Amount, "expected different amount")
+		})
+	}
+}

--- a/precompiles/liquid/integration_test.go
+++ b/precompiles/liquid/integration_test.go
@@ -140,14 +140,24 @@ var _ = Describe("Liquid Vesting precompile with Gnosis Safe (smart contract wal
 	// Common balance constants used across the suite. All amounts are in
 	// aISLM (1 ISLM = 1e18 aISLM) to match the on-chain unit.
 	var (
-		islmInitialOwnerFunding = sdkmath.NewInt(1500).MulRaw(1e18)
-		islmTransferToSafe      = sdkmath.NewInt(500).MulRaw(1e18)
-		islmExpectedSafeFree    = sdkmath.NewInt(1000).MulRaw(1e18)
-		islmOwnerTwoBaseline    = sdkmath.NewInt(1000).MulRaw(1e18)
-		islmOwnerOneFloor       = sdkmath.NewInt(999).MulRaw(1e18)
-		islmOwnerOneCeil        = sdkmath.NewInt(1000).MulRaw(1e18)
-		islmVestingTotal        = sdkmath.NewInt(3000).MulRaw(1e18)
-		islmLiquidationAmount   = sdkmath.NewInt(500).MulRaw(1e18)
+		islmInitialOwnerFunding   = sdkmath.NewInt(1500).MulRaw(1e18)
+		islmTransferToSafe        = sdkmath.NewInt(500).MulRaw(1e18)
+		islmExpectedSafeFree      = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmOwnerTwoBaseline      = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmOwnerOneFloor         = sdkmath.NewInt(999).MulRaw(1e18)
+		islmOwnerOneCeil          = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmVestingTotal          = sdkmath.NewInt(3000).MulRaw(1e18)
+		islmFirstLiquidateAmount  = sdkmath.NewInt(500).MulRaw(1e18)
+		islmSecondLiquidateAmount = sdkmath.NewInt(2000).MulRaw(1e18)
+		islmThirdLiquidateAmount  = sdkmath.NewInt(500).MulRaw(1e18)
+		islmFourthLiquidateAmount = sdkmath.NewInt(100).MulRaw(1e18)
+		islmFirstRedeemAmount     = sdkmath.NewInt(250).MulRaw(1e18)
+		islmSecondRedeemAmount    = sdkmath.NewInt(2000).MulRaw(1e18)
+		islmThirdRedeemAmount     = sdkmath.NewInt(100).MulRaw(1e18)
+		// 1 ISLM gas budget per Safe execTransaction (covers proxy + signature
+		// verification + precompile call). Two execTransactions in this suite,
+		// so owner1 must spend at most 2 ISLM in total across both.
+		islmGasPerExecTransaction = sdkmath.NewInt(1).MulRaw(1e18)
 	)
 
 	BeforeEach(func() {
@@ -372,197 +382,580 @@ var _ = Describe("Liquid Vesting precompile with Gnosis Safe (smart contract wal
 			Expect(ownerTwoFinal.Balance.Amount).To(Equal(islmOwnerTwoBaseline),
 				"owner2 balance must be unchanged by the native vesting wrap")
 
-			// 7) Execute Safe -> LiquidVesting precompile liquidate(500 ISLM).
+			// 7) Authorize Safe to call MsgLiquidate and MsgRedeem on behalf of
+			//    owner1.
 			//
 			// The precompile requires authz whenever the EVM caller (Safe)
 			// differs from tx origin (owner1). Grant it natively here so the
 			// tested action remains the Safe EVM execution path, while setup
 			// stays minimal for this step.
-			liquidateGrant := sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{}))
+			grantExpiry := ptrTime(s.network.GetContext().BlockTime().Add(time.Hour))
 			Expect(s.network.App.AuthzKeeper.SaveGrant(
 				s.network.GetContext(),
 				safeWalletAccAddr,
 				safeOwnerOne.AccAddr,
-				liquidateGrant,
-				ptrTime(s.network.GetContext().BlockTime().Add(time.Hour)),
+				sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{})),
+				grantExpiry,
 			)).To(Succeed(), "failed to grant Safe authz to liquidate via precompile")
+			Expect(s.network.App.AuthzKeeper.SaveGrant(
+				s.network.GetContext(),
+				safeWalletAccAddr,
+				safeOwnerOne.AccAddr,
+				sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgRedeem{})),
+				grantExpiry,
+			)).To(Succeed(), "failed to grant Safe authz to redeem via precompile")
 
 			liquidVestingModuleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
-			moduleBaseBefore := s.network.App.BankKeeper.GetBalance(
-				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
-			).Amount
-			safeBaseBeforeLiquidate := s.network.App.BankKeeper.GetBalance(
-				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
-			).Amount
-			safeSpendableBeforeLiquidate := s.network.App.BankKeeper.SpendableCoin(
-				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
-			).Amount
-			ownerOneBeforeLiquidate, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
-			Expect(err).NotTo(HaveOccurred())
 
-			liquidateCallData, err := s.precompile.ABI.Pack(
-				liquid.LiquidateMethod,
-				safeWalletAddr,
-				safeWalletAddr,
-				islmLiquidationAmount.BigInt(),
-			)
-			Expect(err).NotTo(HaveOccurred(), "failed to pack liquidate call data")
+			// execViaSafe drives the full Gnosis Safe execTransaction flow:
+			//   read nonce -> compute tx hash -> approved-hash signature for
+			//   owner1 -> execTransaction -> verify ExecutionSuccess.
+			// It returns the EVM tx response so callers can introspect logs.
+			//
+			// Threshold = 1 lets us use the "approved hash" signature scheme
+			// ({r=owner1, s=0, v=1}) instead of an off-chain ECDSA signature,
+			// keeping the test free of low-level signing details.
+			execViaSafe := func(targetAddr common.Address, callData []byte, opLabel string) *evmtypes.MsgEthereumTxResponse {
+				GinkgoHelper()
 
-			_, nonceRes, err := s.factory.CallContractAndCheckLogs(
-				safeOwnerOne.Priv,
-				evmtypes.EvmTxArgs{To: &safeWalletAddr},
-				factory.CallArgs{ContractABI: gnosisSafe.ABI, MethodName: "nonce"},
-				testutil.LogCheckArgs{ExpPass: true},
-			)
-			Expect(err).NotTo(HaveOccurred(), "failed to read Safe nonce before liquidate")
-			nonceOut, err := gnosisSafe.ABI.Methods["nonce"].Outputs.Unpack(nonceRes.Ret)
-			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe nonce")
-			nonce, ok := nonceOut[0].(*big.Int)
-			Expect(ok).To(BeTrue(), "Safe nonce output must be *big.Int")
+				_, nonceRes, err := s.factory.CallContractAndCheckLogs(
+					safeOwnerOne.Priv,
+					evmtypes.EvmTxArgs{To: &safeWalletAddr},
+					factory.CallArgs{ContractABI: gnosisSafe.ABI, MethodName: "nonce"},
+					testutil.LogCheckArgs{ExpPass: true},
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to read Safe nonce before "+opLabel)
+				nonceOut, err := gnosisSafe.ABI.Methods["nonce"].Outputs.Unpack(nonceRes.Ret)
+				Expect(err).NotTo(HaveOccurred(), "failed to decode Safe nonce")
+				nonce, ok := nonceOut[0].(*big.Int)
+				Expect(ok).To(BeTrue(), "Safe nonce output must be *big.Int")
 
-			safeTxGas := big.NewInt(500_000)
-			getTxHashArgs := factory.CallArgs{
-				ContractABI: gnosisSafe.ABI,
-				MethodName:  "getTransactionHash",
-				Args: []interface{}{
-					s.precompile.Address(),
-					big.NewInt(0),
-					liquidateCallData,
-					uint8(0), // CALL
-					safeTxGas,
-					big.NewInt(0),
-					big.NewInt(0),
-					common.Address{},
-					common.Address{},
-					nonce,
-				},
-			}
-			_, txHashRes, err := s.factory.CallContractAndCheckLogs(
-				safeOwnerOne.Priv,
-				evmtypes.EvmTxArgs{To: &safeWalletAddr},
-				getTxHashArgs,
-				testutil.LogCheckArgs{ExpPass: true},
-			)
-			Expect(err).NotTo(HaveOccurred(), "failed to calculate Safe tx hash")
-			txHashOut, err := gnosisSafe.ABI.Methods["getTransactionHash"].Outputs.Unpack(txHashRes.Ret)
-			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe tx hash")
-			Expect(txHashOut).To(HaveLen(1))
-			txHash, ok := txHashOut[0].([32]byte)
-			Expect(ok).To(BeTrue(), "Safe tx hash output must be [32]byte")
-			Expect(txHash).NotTo(Equal([32]byte{}), "Safe tx hash must be non-zero")
-
-			// Safe signature format is {r}{s}{v}. For threshold=1 we use the
-			// approved-hash signature form: v=1 and r=owner1 address.
-			signature := make([]byte, 65)
-			copy(signature[12:32], safeOwnerOne.Addr.Bytes())
-			signature[64] = 1
-
-			execTxRes, err := s.factory.ExecuteContractCall(
-				safeOwnerOne.Priv,
-				evmtypes.EvmTxArgs{To: &safeWalletAddr},
-				factory.CallArgs{
-					ContractABI: gnosisSafe.ABI,
-					MethodName:  "execTransaction",
-					Args: []interface{}{
-						s.precompile.Address(),
-						big.NewInt(0),
-						liquidateCallData,
-						uint8(0), // CALL
-						safeTxGas,
-						big.NewInt(0),
-						big.NewInt(0),
-						common.Address{},
-						common.Address{},
-						signature,
+				safeTxGas := big.NewInt(500_000)
+				_, txHashRes, err := s.factory.CallContractAndCheckLogs(
+					safeOwnerOne.Priv,
+					evmtypes.EvmTxArgs{To: &safeWalletAddr},
+					factory.CallArgs{
+						ContractABI: gnosisSafe.ABI,
+						MethodName:  "getTransactionHash",
+						Args: []interface{}{
+							targetAddr,
+							big.NewInt(0),
+							callData,
+							uint8(0), // CALL
+							safeTxGas,
+							big.NewInt(0),
+							big.NewInt(0),
+							common.Address{},
+							common.Address{},
+							nonce,
+						},
 					},
-				},
-			)
-			Expect(err).NotTo(HaveOccurred(), "failed to execute Safe liquidate transaction")
-			execRes, err := s.factory.GetEvmTransactionResponseFromTxResult(execTxRes)
-			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe liquidate tx response")
-			execOut, err := gnosisSafe.ABI.Methods["execTransaction"].Outputs.Unpack(execRes.Ret)
-			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe execTransaction output")
-			Expect(execOut).To(HaveLen(1))
-			execSuccess, ok := execOut[0].(bool)
-			Expect(ok).To(BeTrue(), "execTransaction output must be bool")
-			Expect(execSuccess).To(BeTrue(), "Safe liquidate execTransaction must succeed")
+					testutil.LogCheckArgs{ExpPass: true},
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to calculate Safe tx hash for "+opLabel)
+				txHashOut, err := gnosisSafe.ABI.Methods["getTransactionHash"].Outputs.Unpack(txHashRes.Ret)
+				Expect(err).NotTo(HaveOccurred(), "failed to decode Safe tx hash")
+				Expect(txHashOut).To(HaveLen(1))
+				txHash, ok := txHashOut[0].([32]byte)
+				Expect(ok).To(BeTrue(), "Safe tx hash output must be [32]byte")
+				Expect(txHash).NotTo(Equal([32]byte{}), "Safe tx hash must be non-zero")
 
-			executionSuccessEvent := gnosisSafe.ABI.Events["ExecutionSuccess"]
-			executionSuccessFound := false
-			for i := range execRes.Logs {
-				l := execRes.Logs[i]
-				if len(l.Topics) == 0 || l.Topics[0] != executionSuccessEvent.ID.String() {
-					continue
-				}
-				if common.HexToAddress(l.Address) != safeWalletAddr {
-					continue
-				}
-				executionSuccessFound = true
-				break
-			}
-			Expect(executionSuccessFound).To(BeTrue(), "Safe must emit ExecutionSuccess for liquidate")
-			Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after Safe liquidate")
+				// Safe signature format is {r}{s}{v}. For threshold=1 we use the
+				// approved-hash signature form: v=1 and r=owner1 address.
+				signature := make([]byte, 65)
+				copy(signature[12:32], safeOwnerOne.Addr.Bytes())
+				signature[64] = 1
 
-			// 8) Post-liquidation invariants.
-			ownerOneAfterLiquidate, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
-			Expect(err).NotTo(HaveOccurred())
-			ownerOneLiquidateSpend := ownerOneBeforeLiquidate.Balance.Amount.Sub(ownerOneAfterLiquidate.Balance.Amount)
-			Expect(ownerOneLiquidateSpend.IsNegative()).To(BeFalse(), "owner1 balance must not increase after Safe liquidate")
-			Expect(ownerOneLiquidateSpend.LTE(sdkmath.NewInt(1).MulRaw(1e18))).To(BeTrue(),
-				"owner1 must spend no more than 1 ISLM on Safe liquidate gas")
+				execTxRes, err := s.factory.ExecuteContractCall(
+					safeOwnerOne.Priv,
+					evmtypes.EvmTxArgs{To: &safeWalletAddr},
+					factory.CallArgs{
+						ContractABI: gnosisSafe.ABI,
+						MethodName:  "execTransaction",
+						Args: []interface{}{
+							targetAddr,
+							big.NewInt(0),
+							callData,
+							uint8(0), // CALL
+							safeTxGas,
+							big.NewInt(0),
+							big.NewInt(0),
+							common.Address{},
+							common.Address{},
+							signature,
+						},
+					},
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to execute Safe "+opLabel+" transaction")
+				execRes, err := s.factory.GetEvmTransactionResponseFromTxResult(execTxRes)
+				Expect(err).NotTo(HaveOccurred(), "failed to decode Safe "+opLabel+" tx response")
+				execOut, err := gnosisSafe.ABI.Methods["execTransaction"].Outputs.Unpack(execRes.Ret)
+				Expect(err).NotTo(HaveOccurred(), "failed to decode Safe execTransaction output")
+				Expect(execOut).To(HaveLen(1))
+				execSuccess, ok := execOut[0].(bool)
+				Expect(ok).To(BeTrue(), "execTransaction output must be bool")
+				Expect(execSuccess).To(BeTrue(), "Safe "+opLabel+" execTransaction must succeed")
 
-			safeBaseAfterLiquidate := s.network.App.BankKeeper.GetBalance(
-				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
-			).Amount
-			safeSpendableAfterLiquidate := s.network.App.BankKeeper.SpendableCoin(
-				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
-			).Amount
-			safeLockedAfterLiquidate := safeBaseAfterLiquidate.Sub(safeSpendableAfterLiquidate)
-			moduleBaseAfter := s.network.App.BankKeeper.GetBalance(
-				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
-			).Amount
-
-			liquidDenom := ""
-			liquidAmount := sdkmath.ZeroInt()
-			for _, coin := range s.network.App.BankKeeper.GetAllBalances(s.network.GetContext(), safeWalletAccAddr) {
-				if strings.HasPrefix(coin.Denom, "aLIQUID") {
-					liquidDenom = coin.Denom
-					liquidAmount = coin.Amount
+				executionSuccessEvent := gnosisSafe.ABI.Events["ExecutionSuccess"]
+				executionSuccessFound := false
+				for i := range execRes.Logs {
+					l := execRes.Logs[i]
+					if len(l.Topics) == 0 || l.Topics[0] != executionSuccessEvent.ID.String() {
+						continue
+					}
+					if common.HexToAddress(l.Address) != safeWalletAddr {
+						continue
+					}
+					executionSuccessFound = true
 					break
 				}
+				Expect(executionSuccessFound).To(BeTrue(), "Safe must emit ExecutionSuccess for "+opLabel)
+				Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after Safe "+opLabel)
+				return execRes
 			}
 
-			GinkgoWriter.Printf(
-				"liquidate balances: safeBaseBefore=%s safeBaseAfter=%s spendableBefore=%s spendableAfter=%s lockedAfter=%s moduleBefore=%s moduleAfter=%s liquidDenom=%s liquidAmount=%s\n",
-				safeBaseBeforeLiquidate.String(),
-				safeBaseAfterLiquidate.String(),
-				safeSpendableBeforeLiquidate.String(),
-				safeSpendableAfterLiquidate.String(),
-				safeLockedAfterLiquidate.String(),
-				moduleBaseBefore.String(),
-				moduleBaseAfter.String(),
-				liquidDenom,
-				liquidAmount.String(),
-			)
+			// liquidateViaSafe and redeemViaSafe pack the precompile call data
+			// and dispatch through the shared Safe execTransaction helper. Both
+			// take an explicit `to` so we can exercise the from == to (self)
+			// path AND the from != to (cross-account) path against the same
+			// Safe-as-vesting-account fixture.
+			liquidateViaSafe := func(amount sdkmath.Int, to common.Address) *evmtypes.MsgEthereumTxResponse {
+				GinkgoHelper()
+				callData, err := s.precompile.ABI.Pack(
+					liquid.LiquidateMethod,
+					safeWalletAddr,
+					to,
+					amount.BigInt(),
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to pack liquidate call data")
+				return execViaSafe(s.precompile.Address(), callData, "liquidate")
+			}
+			redeemViaSafe := func(denom string, amount sdkmath.Int, to common.Address) *evmtypes.MsgEthereumTxResponse {
+				GinkgoHelper()
+				callData, err := s.precompile.ABI.Pack(
+					liquid.RedeemMethod,
+					safeWalletAddr,
+					to,
+					denom,
+					amount.BigInt(),
+				)
+				Expect(err).NotTo(HaveOccurred(), "failed to pack redeem call data")
+				return execViaSafe(s.precompile.Address(), callData, "redeem")
+			}
 
-			Expect(safeSpendableAfterLiquidate).To(Equal(islmExpectedSafeFree),
+			// allLiquidBalances returns the bank balance of the Safe filtered to
+			// liquid-vesting denoms ("aLIQUID*"), keyed by denom for easy
+			// per-denom assertions.
+			allLiquidBalances := func() map[string]sdkmath.Int {
+				out := map[string]sdkmath.Int{}
+				for _, coin := range s.network.App.BankKeeper.GetAllBalances(s.network.GetContext(), safeWalletAccAddr) {
+					if strings.HasPrefix(coin.Denom, "aLIQUID") {
+						out[coin.Denom] = coin.Amount
+					}
+				}
+				return out
+			}
+
+			// safeAndModuleSnapshot captures the bank baselines we assert on
+			// across each precompile call: Safe's base denom, Safe's spendable
+			// base denom, the module's base denom, and the Safe's balance of
+			// the given liquid denom (use empty string to skip).
+			type bankSnapshot struct {
+				safeBase      sdkmath.Int
+				safeSpendable sdkmath.Int
+				moduleBase    sdkmath.Int
+				safeLiquid    sdkmath.Int
+			}
+			safeAndModuleSnapshot := func(liquidDenom string) bankSnapshot {
+				ctx := s.network.GetContext()
+				snap := bankSnapshot{
+					safeBase:      s.network.App.BankKeeper.GetBalance(ctx, safeWalletAccAddr, utils.BaseDenom).Amount,
+					safeSpendable: s.network.App.BankKeeper.SpendableCoin(ctx, safeWalletAccAddr, utils.BaseDenom).Amount,
+					moduleBase:    s.network.App.BankKeeper.GetBalance(ctx, liquidVestingModuleAddr, utils.BaseDenom).Amount,
+				}
+				if liquidDenom != "" {
+					snap.safeLiquid = s.network.App.BankKeeper.GetBalance(ctx, safeWalletAccAddr, liquidDenom).Amount
+				}
+				return snap
+			}
+
+			// 8) FIRST liquidation: 500 ISLM -> 500 aLIQUID0.
+			moduleBaseBeforeFirst := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
+			).Amount
+			safeBaseBeforeFirst := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeSpendableBeforeFirst := s.network.App.BankKeeper.SpendableCoin(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			ownerOneBeforeFirst, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			liquidateViaSafe(islmFirstLiquidateAmount, safeWalletAddr)
+
+			// 8a) Post-first-liquidation invariants.
+			//
+			// Expected state changes:
+			//   - Safe locked vesting: 3000 -> 2500
+			//   - Safe spendable: 1000 (unchanged)
+			//   - Safe bank: 4000 -> 3500 (debited 500)
+			//   - Module bank: 0 -> 500 (credited 500)
+			//   - Safe receives 500 of a brand-new aLIQUID0 denom
+			ownerOneAfterFirst, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneFirstSpend := ownerOneBeforeFirst.Balance.Amount.Sub(ownerOneAfterFirst.Balance.Amount)
+			Expect(ownerOneFirstSpend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the first Safe liquidate")
+			Expect(ownerOneFirstSpend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the first Safe liquidate gas")
+
+			safeBaseAfterFirst := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeSpendableAfterFirst := s.network.App.BankKeeper.SpendableCoin(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeLockedAfterFirst := safeBaseAfterFirst.Sub(safeSpendableAfterFirst)
+			moduleBaseAfterFirst := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
+			).Amount
+
+			Expect(safeSpendableAfterFirst).To(Equal(islmExpectedSafeFree),
 				"Safe spendable ISLM must remain exactly 1000 after liquidating locked vesting")
-			Expect(safeLockedAfterLiquidate).To(Equal(islmVestingTotal.Sub(islmLiquidationAmount)),
-				"Safe locked vesting ISLM must be 2500 after liquidating 500")
-			Expect(safeBaseBeforeLiquidate.Sub(safeBaseAfterLiquidate)).To(Equal(islmLiquidationAmount),
-				"Safe base ISLM bank balance must decrease exactly by the liquidated amount")
-			Expect(moduleBaseAfter.Sub(moduleBaseBefore)).To(Equal(islmLiquidationAmount),
-				"liquid vesting module ISLM balance must increase exactly by the liquidated amount")
-			Expect(safeBaseBeforeLiquidate.Add(moduleBaseBefore)).To(Equal(safeBaseAfterLiquidate.Add(moduleBaseAfter)),
-				"Safe ISLM decrease must be fully accounted for by the liquid vesting module increase")
-			Expect(liquidDenom).NotTo(BeEmpty(), "Safe must receive a liquid vesting denom")
-			Expect(liquidAmount).To(Equal(islmLiquidationAmount),
-				"Safe must receive exactly 500 ISLM-equivalent liquid tokens")
-			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), liquidDenom).Amount).To(Equal(islmLiquidationAmount),
-				"liquid token supply must equal the minted amount; no extra liquid tokens may appear")
-
-			Expect(safeSpendableBeforeLiquidate).To(Equal(safeSpendableAfterLiquidate),
+			Expect(safeSpendableBeforeFirst).To(Equal(safeSpendableAfterFirst),
 				"liquidating locked vesting must not change Safe spendable ISLM")
+			Expect(safeLockedAfterFirst).To(Equal(islmVestingTotal.Sub(islmFirstLiquidateAmount)),
+				"Safe locked vesting ISLM must be 2500 after liquidating 500")
+			Expect(safeBaseBeforeFirst.Sub(safeBaseAfterFirst)).To(Equal(islmFirstLiquidateAmount),
+				"Safe base ISLM bank balance must decrease exactly by the first liquidated amount")
+			Expect(moduleBaseAfterFirst.Sub(moduleBaseBeforeFirst)).To(Equal(islmFirstLiquidateAmount),
+				"liquid vesting module ISLM balance must increase exactly by the first liquidated amount")
+			Expect(safeBaseBeforeFirst.Add(moduleBaseBeforeFirst)).To(Equal(safeBaseAfterFirst.Add(moduleBaseAfterFirst)),
+				"Safe ISLM decrease must be fully accounted for by the liquid vesting module increase (first call)")
+
+			liquidAfterFirst := allLiquidBalances()
+			Expect(liquidAfterFirst).To(HaveLen(1),
+				"Safe must hold exactly one liquid denom after the first liquidation")
+			Expect(liquidAfterFirst).To(HaveKeyWithValue("aLIQUID0", islmFirstLiquidateAmount),
+				"first liquidation must mint exactly 500 of aLIQUID0 into Safe")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount).
+				To(Equal(islmFirstLiquidateAmount),
+					"aLIQUID0 supply must equal the first mint; no extra liquid tokens may appear")
+
+			// 9) SECOND liquidation: 2000 ISLM -> 2000 aLIQUID1.
+			//
+			// Each Liquidate call increments the keeper's denom counter and
+			// produces a NEW liquid denom; aLIQUID0 from the previous step
+			// stays untouched in Safe's balance.
+			moduleBaseBeforeSecond := moduleBaseAfterFirst
+			safeBaseBeforeSecond := safeBaseAfterFirst
+			safeSpendableBeforeSecond := safeSpendableAfterFirst
+			ownerOneBeforeSecond, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			liquidateViaSafe(islmSecondLiquidateAmount, safeWalletAddr)
+
+			// 9a) Post-second-liquidation invariants.
+			//
+			// Expected state changes (cumulative):
+			//   - Safe locked vesting: 2500 -> 500
+			//   - Safe spendable: 1000 (unchanged)
+			//   - Safe bank: 3500 -> 1500 (debited 2000 more)
+			//   - Module bank: 500 -> 2500 (credited 2000 more)
+			//   - Safe gains a SECOND liquid denom aLIQUID1 with 2000 minted
+			//   - aLIQUID0 stays at exactly 500 (untouched by the second call)
+			ownerOneAfterSecond, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneSecondSpend := ownerOneBeforeSecond.Balance.Amount.Sub(ownerOneAfterSecond.Balance.Amount)
+			Expect(ownerOneSecondSpend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the second Safe liquidate")
+			Expect(ownerOneSecondSpend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the second Safe liquidate gas")
+
+			safeBaseAfterSecond := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeSpendableAfterSecond := s.network.App.BankKeeper.SpendableCoin(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeLockedAfterSecond := safeBaseAfterSecond.Sub(safeSpendableAfterSecond)
+			moduleBaseAfterSecond := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
+			).Amount
+
+			expectedFinalLocked := islmVestingTotal.Sub(islmFirstLiquidateAmount).Sub(islmSecondLiquidateAmount)
+			expectedFinalModule := islmFirstLiquidateAmount.Add(islmSecondLiquidateAmount)
+
+			Expect(safeSpendableAfterSecond).To(Equal(islmExpectedSafeFree),
+				"Safe spendable ISLM must still be exactly 1000 after the second liquidation")
+			Expect(safeSpendableBeforeSecond).To(Equal(safeSpendableAfterSecond),
+				"second liquidation must not change Safe spendable ISLM")
+			Expect(safeLockedAfterSecond).To(Equal(expectedFinalLocked),
+				"Safe locked vesting ISLM must be 500 after liquidating 500 + 2000 of 3000")
+			Expect(safeBaseBeforeSecond.Sub(safeBaseAfterSecond)).To(Equal(islmSecondLiquidateAmount),
+				"Safe base ISLM bank balance must decrease exactly by the second liquidated amount")
+			Expect(moduleBaseAfterSecond.Sub(moduleBaseBeforeSecond)).To(Equal(islmSecondLiquidateAmount),
+				"module ISLM balance must increase exactly by the second liquidated amount")
+			Expect(moduleBaseAfterSecond).To(Equal(expectedFinalModule),
+				"module ISLM balance must equal the sum of all liquidations (500 + 2000 = 2500)")
+			Expect(safeBaseBeforeSecond.Add(moduleBaseBeforeSecond)).To(Equal(safeBaseAfterSecond.Add(moduleBaseAfterSecond)),
+				"Safe ISLM decrease must be fully accounted for by the module increase (second call)")
+
+			// 9b) Liquid token bookkeeping after both liquidations.
+			liquidAfterSecond := allLiquidBalances()
+			Expect(liquidAfterSecond).To(HaveLen(2),
+				"Safe must hold exactly two distinct liquid denoms after two liquidations")
+			Expect(liquidAfterSecond).To(HaveKeyWithValue("aLIQUID0", islmFirstLiquidateAmount),
+				"aLIQUID0 amount in Safe must remain 500 (untouched by the second liquidation)")
+			Expect(liquidAfterSecond).To(HaveKeyWithValue("aLIQUID1", islmSecondLiquidateAmount),
+				"second liquidation must mint exactly 2000 of aLIQUID1 into Safe")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount).
+				To(Equal(islmFirstLiquidateAmount),
+					"aLIQUID0 total supply must remain 500 after the second liquidation")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID1").Amount).
+				To(Equal(islmSecondLiquidateAmount),
+					"aLIQUID1 total supply must equal the second mint; no extra liquid tokens may appear")
+
+			// 10) FIRST redeem: 250 of aLIQUID0 back into base ISLM.
+			//
+			// Redeem flow inside the keeper:
+			//   - Safe (redeemFrom) -> module: 250 aLIQUID0
+			//   - module burns      :         250 aLIQUID0   (supply -= 250)
+			//   - module -> Safe (redeemTo):  250 aISLM
+			//
+			// Because aLIQUID0's lockup window has not elapsed yet (test runs
+			// in milliseconds, the first lockup period is ~100000s long), the
+			// keeper applies the corresponding diffPeriods as a NEW vesting
+			// schedule on the Safe (redeemTo). That means the 250 aISLM that
+			// just landed in the Safe are immediately re-locked under that
+			// schedule, so Safe's spendable ISLM must NOT change.
+			snapBeforeRedeem1 := safeAndModuleSnapshot("aLIQUID0")
+			ownerOneBeforeRedeem1, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			supplyLiquid0BeforeRedeem1 := s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount
+
+			redeemViaSafe("aLIQUID0", islmFirstRedeemAmount, safeWalletAddr)
+
+			snapAfterRedeem1 := safeAndModuleSnapshot("aLIQUID0")
+			ownerOneAfterRedeem1, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneRedeem1Spend := ownerOneBeforeRedeem1.Balance.Amount.Sub(ownerOneAfterRedeem1.Balance.Amount)
+			Expect(ownerOneRedeem1Spend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the first Safe redeem")
+			Expect(ownerOneRedeem1Spend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the first Safe redeem gas")
+
+			Expect(snapAfterRedeem1.safeBase.Sub(snapBeforeRedeem1.safeBase)).To(Equal(islmFirstRedeemAmount),
+				"Safe base ISLM bank balance must increase exactly by the first redeemed amount (250)")
+			Expect(snapBeforeRedeem1.safeLiquid.Sub(snapAfterRedeem1.safeLiquid)).To(Equal(islmFirstRedeemAmount),
+				"Safe aLIQUID0 balance must decrease exactly by the first redeemed amount (250)")
+			Expect(snapBeforeRedeem1.moduleBase.Sub(snapAfterRedeem1.moduleBase)).To(Equal(islmFirstRedeemAmount),
+				"module ISLM balance must decrease exactly by the first redeemed amount (250)")
+			Expect(snapBeforeRedeem1.safeBase.Add(snapBeforeRedeem1.moduleBase)).
+				To(Equal(snapAfterRedeem1.safeBase.Add(snapAfterRedeem1.moduleBase)),
+					"module ISLM decrease must be fully accounted for by the Safe ISLM increase (first redeem)")
+			Expect(supplyLiquid0BeforeRedeem1.Sub(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount)).
+				To(Equal(islmFirstRedeemAmount),
+					"aLIQUID0 supply must decrease by exactly the first redeemed amount via burn")
+			Expect(snapAfterRedeem1.safeLiquid).To(Equal(islmFirstLiquidateAmount.Sub(islmFirstRedeemAmount)),
+				"Safe must keep exactly 500 - 250 = 250 of aLIQUID0 after the first redeem")
+			Expect(snapAfterRedeem1.safeSpendable).To(Equal(snapBeforeRedeem1.safeSpendable),
+				"first redeem must not change Safe spendable ISLM (the redeemed amount lands re-locked)")
+
+			// 11) SECOND redeem: 2000 of aLIQUID1 (full supply) back into base ISLM.
+			//
+			// This fully redeems aLIQUID1: decreasedPeriods.TotalAmount() == 0,
+			// so the keeper deletes the aLIQUID1 denom from x/liquidvesting and
+			// disables the corresponding ERC20 conversion. After this step the
+			// Safe must hold zero aLIQUID1.
+			snapBeforeRedeem2 := safeAndModuleSnapshot("aLIQUID1")
+			ownerOneBeforeRedeem2, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			supplyLiquid1BeforeRedeem2 := s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID1").Amount
+			Expect(supplyLiquid1BeforeRedeem2).To(Equal(islmSecondRedeemAmount),
+				"sanity: aLIQUID1 total supply must equal the amount we are about to redeem")
+
+			redeemViaSafe("aLIQUID1", islmSecondRedeemAmount, safeWalletAddr)
+
+			snapAfterRedeem2 := safeAndModuleSnapshot("aLIQUID1")
+			ownerOneAfterRedeem2, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneRedeem2Spend := ownerOneBeforeRedeem2.Balance.Amount.Sub(ownerOneAfterRedeem2.Balance.Amount)
+			Expect(ownerOneRedeem2Spend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the second Safe redeem")
+			Expect(ownerOneRedeem2Spend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the second Safe redeem gas")
+
+			Expect(snapAfterRedeem2.safeBase.Sub(snapBeforeRedeem2.safeBase)).To(Equal(islmSecondRedeemAmount),
+				"Safe base ISLM bank balance must increase exactly by the second redeemed amount (2000)")
+			Expect(snapBeforeRedeem2.safeLiquid.Sub(snapAfterRedeem2.safeLiquid)).To(Equal(islmSecondRedeemAmount),
+				"Safe aLIQUID1 balance must decrease exactly by the second redeemed amount (2000)")
+			Expect(snapBeforeRedeem2.moduleBase.Sub(snapAfterRedeem2.moduleBase)).To(Equal(islmSecondRedeemAmount),
+				"module ISLM balance must decrease exactly by the second redeemed amount (2000)")
+			Expect(snapBeforeRedeem2.safeBase.Add(snapBeforeRedeem2.moduleBase)).
+				To(Equal(snapAfterRedeem2.safeBase.Add(snapAfterRedeem2.moduleBase)),
+					"module ISLM decrease must be fully accounted for by the Safe ISLM increase (second redeem)")
+			Expect(snapAfterRedeem2.safeLiquid.IsZero()).To(BeTrue(),
+				"Safe must hold zero aLIQUID1 after redeeming the entire supply")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID1").Amount.IsZero()).
+				To(BeTrue(), "aLIQUID1 total supply must be zero after a full redeem")
+			Expect(snapAfterRedeem2.safeSpendable).To(Equal(snapBeforeRedeem2.safeSpendable),
+				"second redeem must not change Safe spendable ISLM (the redeemed amount lands re-locked)")
+
+			// 11a) Cumulative liquid-token bookkeeping after both redeems.
+			//   - aLIQUID0: 500 minted - 250 redeemed = 250 remaining in Safe
+			//   - aLIQUID1: 2000 minted - 2000 redeemed = 0 (denom deleted)
+			liquidAfterRedeems := allLiquidBalances()
+			Expect(liquidAfterRedeems).To(HaveKeyWithValue("aLIQUID0", islmFirstLiquidateAmount.Sub(islmFirstRedeemAmount)),
+				"aLIQUID0 in Safe must equal the unredeemed remainder after the first partial redeem")
+			Expect(liquidAfterRedeems).NotTo(HaveKey("aLIQUID1"),
+				"aLIQUID1 must be fully drained from Safe after the second (full) redeem")
+
+			// 12) THIRD liquidation: another 500 ISLM -> brand-new aLIQUID2.
+			//
+			// The keeper's denom counter is monotonic; even though aLIQUID1 was
+			// just deleted, the counter is at 2 by now and the new denom is
+			// aLIQUID2 (not a recycled aLIQUID1).
+			snapBeforeLiquidate3 := safeAndModuleSnapshot("")
+			ownerOneBeforeLiquidate3, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			liquidateViaSafe(islmThirdLiquidateAmount, safeWalletAddr)
+
+			snapAfterLiquidate3 := safeAndModuleSnapshot("")
+			ownerOneAfterLiquidate3, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneLiquidate3Spend := ownerOneBeforeLiquidate3.Balance.Amount.Sub(ownerOneAfterLiquidate3.Balance.Amount)
+			Expect(ownerOneLiquidate3Spend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the third Safe liquidate")
+			Expect(ownerOneLiquidate3Spend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the third Safe liquidate gas")
+
+			Expect(snapBeforeLiquidate3.safeBase.Sub(snapAfterLiquidate3.safeBase)).To(Equal(islmThirdLiquidateAmount),
+				"Safe base ISLM bank balance must decrease exactly by the third liquidated amount (500)")
+			Expect(snapAfterLiquidate3.moduleBase.Sub(snapBeforeLiquidate3.moduleBase)).To(Equal(islmThirdLiquidateAmount),
+				"module ISLM balance must increase exactly by the third liquidated amount (500)")
+			Expect(snapBeforeLiquidate3.safeBase.Add(snapBeforeLiquidate3.moduleBase)).
+				To(Equal(snapAfterLiquidate3.safeBase.Add(snapAfterLiquidate3.moduleBase)),
+					"Safe ISLM decrease must be fully accounted for by the module increase (third liquidation)")
+			Expect(snapAfterLiquidate3.safeSpendable).To(Equal(snapBeforeLiquidate3.safeSpendable),
+				"third liquidation must not change Safe spendable ISLM")
+
+			liquidAfterLiquidate3 := allLiquidBalances()
+			Expect(liquidAfterLiquidate3).To(HaveKeyWithValue("aLIQUID2", islmThirdLiquidateAmount),
+				"third liquidation must mint exactly 500 of aLIQUID2 into Safe")
+			Expect(liquidAfterLiquidate3).To(HaveKeyWithValue("aLIQUID0", islmFirstLiquidateAmount.Sub(islmFirstRedeemAmount)),
+				"aLIQUID0 in Safe must remain at 250 (untouched by the third liquidation)")
+			Expect(liquidAfterLiquidate3).NotTo(HaveKey("aLIQUID1"),
+				"aLIQUID1 must remain absent (counter is monotonic; new denom is aLIQUID2)")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID2").Amount).
+				To(Equal(islmThirdLiquidateAmount),
+					"aLIQUID2 total supply must equal the third mint; no extra liquid tokens may appear")
+
+			// 13) THIRD redeem with redeemFrom != redeemTo: 100 aLIQUID0
+			//     redeemed from Safe, principal credited to owner2.
+			//
+			// This explicitly exercises the cross-account redeem branch of
+			// the precompile mirror (where redeemFrom and redeemTo are two
+			// distinct addresses, both passed to mirrorBankBaseDeltasIntoStateDB):
+			//   - Safe (redeemFrom): only aLIQUID0 moves; base aISLM is unchanged,
+			//     so the mirror snapshot resolves to a zero delta and is a no-op.
+			//   - owner2 (redeemTo): receives 100 aISLM from the module account,
+			//     so the mirror must emit a single Add(owner2, 100) entry.
+			//
+			// This is the regression case for the dedup logic: previous
+			// versions of the mirror called twice on the same address would
+			// double-credit when from == to; here we additionally pin down the
+			// "two distinct addresses, distinct mirror entries" path so that a
+			// future regression in either direction is caught.
+			snapBeforeRedeem3 := safeAndModuleSnapshot("aLIQUID0")
+			ownerTwoBeforeRedeem3, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneBeforeRedeem3, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			supplyLiquid0BeforeRedeem3 := s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount
+
+			redeemViaSafe("aLIQUID0", islmThirdRedeemAmount, safeOwnerTwo.Addr)
+
+			snapAfterRedeem3 := safeAndModuleSnapshot("aLIQUID0")
+			ownerTwoAfterRedeem3, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneAfterRedeem3, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			ownerOneRedeem3Spend := ownerOneBeforeRedeem3.Balance.Amount.Sub(ownerOneAfterRedeem3.Balance.Amount)
+			Expect(ownerOneRedeem3Spend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the cross-account Safe redeem")
+			Expect(ownerOneRedeem3Spend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the cross-account Safe redeem gas")
+
+			Expect(snapAfterRedeem3.safeBase).To(Equal(snapBeforeRedeem3.safeBase),
+				"Safe base ISLM must NOT change on cross-account redeem (Safe is redeemFrom only)")
+			Expect(snapBeforeRedeem3.safeLiquid.Sub(snapAfterRedeem3.safeLiquid)).To(Equal(islmThirdRedeemAmount),
+				"Safe aLIQUID0 balance must decrease exactly by the cross-account redeemed amount (100)")
+			Expect(snapBeforeRedeem3.moduleBase.Sub(snapAfterRedeem3.moduleBase)).To(Equal(islmThirdRedeemAmount),
+				"module ISLM balance must decrease exactly by the cross-account redeemed amount (100)")
+			Expect(ownerTwoAfterRedeem3.Balance.Amount.Sub(ownerTwoBeforeRedeem3.Balance.Amount)).
+				To(Equal(islmThirdRedeemAmount),
+					"owner2 base ISLM must increase exactly by the cross-account redeemed amount (100)")
+			Expect(supplyLiquid0BeforeRedeem3.Sub(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID0").Amount)).
+				To(Equal(islmThirdRedeemAmount),
+					"aLIQUID0 supply must decrease by exactly the cross-account redeemed amount via burn")
+			Expect(snapBeforeRedeem3.moduleBase.Add(ownerTwoBeforeRedeem3.Balance.Amount)).
+				To(Equal(snapAfterRedeem3.moduleBase.Add(ownerTwoAfterRedeem3.Balance.Amount)),
+					"module ISLM decrease must be fully accounted for by owner2 ISLM increase (cross-account redeem)")
+
+			// 14) FOURTH liquidate with liquidateFrom != liquidateTo: 100 aISLM
+			//     of Safe's locked vesting -> owner2 receives the freshly minted
+			//     liquid denom (aLIQUID3).
+			//
+			// Mirror invariant: the only base-denom mover here is liquidateFrom
+			// (Safe), debited 100 aISLM via SendCoinsFromAccountToModule. The
+			// liquidateTo side (owner2) receives ONLY aLIQUID3, which is NOT
+			// the EVM gas denom, so even though we sample its base balance the
+			// mirror must produce a zero delta for owner2.
+			snapBeforeLiquidate4 := safeAndModuleSnapshot("")
+			ownerTwoBeforeLiquidate4, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneBeforeLiquidate4, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			liquidateViaSafe(islmFourthLiquidateAmount, safeOwnerTwo.Addr)
+
+			snapAfterLiquidate4 := safeAndModuleSnapshot("")
+			ownerTwoAfterLiquidate4, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneAfterLiquidate4, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			ownerOneLiquidate4Spend := ownerOneBeforeLiquidate4.Balance.Amount.Sub(ownerOneAfterLiquidate4.Balance.Amount)
+			Expect(ownerOneLiquidate4Spend.IsNegative()).To(BeFalse(),
+				"owner1 balance must not increase after the cross-account Safe liquidate")
+			Expect(ownerOneLiquidate4Spend.LTE(islmGasPerExecTransaction)).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on the cross-account Safe liquidate gas")
+
+			Expect(snapBeforeLiquidate4.safeBase.Sub(snapAfterLiquidate4.safeBase)).
+				To(Equal(islmFourthLiquidateAmount),
+					"Safe base ISLM must decrease exactly by the cross-account liquidated amount (100)")
+			Expect(snapAfterLiquidate4.moduleBase.Sub(snapBeforeLiquidate4.moduleBase)).
+				To(Equal(islmFourthLiquidateAmount),
+					"module ISLM must increase exactly by the cross-account liquidated amount (100)")
+			Expect(snapBeforeLiquidate4.safeBase.Add(snapBeforeLiquidate4.moduleBase)).
+				To(Equal(snapAfterLiquidate4.safeBase.Add(snapAfterLiquidate4.moduleBase)),
+					"Safe ISLM decrease must be fully accounted for by the module increase (cross-account liquidate)")
+			Expect(ownerTwoAfterLiquidate4.Balance.Amount).To(Equal(ownerTwoBeforeLiquidate4.Balance.Amount),
+				"owner2 base ISLM must NOT change on cross-account liquidate (owner2 only receives aLIQUID3)")
+
+			ownerTwoAccBalances := s.network.App.BankKeeper.GetAllBalances(s.network.GetContext(), safeOwnerTwo.AccAddr)
+			Expect(ownerTwoAccBalances.AmountOf("aLIQUID3")).To(Equal(islmFourthLiquidateAmount),
+				"owner2 must receive exactly 100 of the freshly minted aLIQUID3 (counter is monotonic; previously deleted aLIQUID1 is NOT recycled)")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), "aLIQUID3").Amount).
+				To(Equal(islmFourthLiquidateAmount),
+					"aLIQUID3 total supply must equal the fourth mint; no extra liquid tokens may appear")
+			liquidAfterLiquidate4 := allLiquidBalances()
+			Expect(liquidAfterLiquidate4).NotTo(HaveKey("aLIQUID3"),
+				"Safe must NOT receive aLIQUID3 - it was minted to owner2 (cross-account liquidate)")
 		})
 	})
 })

--- a/precompiles/liquid/integration_test.go
+++ b/precompiles/liquid/integration_test.go
@@ -1,0 +1,568 @@
+package liquid_test
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/ginkgo/v2"
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/gomega"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	sdkauthz "github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/haqq-network/haqq/precompiles/liquid"
+	"github.com/haqq-network/haqq/precompiles/testutil"
+	safecontracts "github.com/haqq-network/haqq/precompiles/testutil/contracts/safe"
+	haqqtestutil "github.com/haqq-network/haqq/testutil"
+	"github.com/haqq-network/haqq/testutil/integration/haqq/factory"
+	"github.com/haqq-network/haqq/testutil/integration/haqq/grpc"
+	"github.com/haqq-network/haqq/testutil/integration/haqq/keyring"
+	"github.com/haqq-network/haqq/testutil/integration/haqq/network"
+	testutiltx "github.com/haqq-network/haqq/testutil/tx"
+	haqqtypes "github.com/haqq-network/haqq/types"
+	"github.com/haqq-network/haqq/utils"
+	evmtypes "github.com/haqq-network/haqq/x/evm/types"
+	liquidtypes "github.com/haqq-network/haqq/x/liquidvesting/types"
+	vestingtypes "github.com/haqq-network/haqq/x/vesting/types"
+)
+
+// TestLiquidIntegrationTestSuite runs the Ginkgo integration suite for the
+// liquid vesting precompile. It coexists with the testify suite from
+// setup_test.go - both are independent entry points.
+func TestLiquidIntegrationTestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Liquid Vesting Precompile Integration Suite")
+}
+
+type liquidSafeSuite struct {
+	network     *network.UnitTestNetwork
+	factory     factory.TxFactory
+	grpcHandler grpc.Handler
+	precompile  *liquid.Precompile
+	keyring     keyring.Keyring
+}
+
+func (s *liquidSafeSuite) setupNetwork(kr keyring.Keyring) {
+	customGenesis := network.CustomGenesisState{}
+	lvGenesis := liquidtypes.DefaultGenesisState()
+	lvGenesis.Params.MinimumLiquidationAmount = sdkmath.NewInt(1_000_000)
+	customGenesis[liquidtypes.ModuleName] = lvGenesis
+
+	nw := network.NewUnitTestNetwork(
+		network.WithPreFundedAccounts(kr.GetAllAccAddrs()...),
+		network.WithCustomGenesis(customGenesis),
+	)
+	gh := grpc.NewIntegrationHandler(nw)
+	pc, err := liquid.NewPrecompile(nw.App.LiquidVestingKeeper, nw.App.AuthzKeeper)
+	Expect(err).NotTo(HaveOccurred(), "failed to create liquid vesting precompile")
+
+	s.network = nw
+	s.factory = factory.New(nw, gh)
+	s.grpcHandler = gh
+	s.precompile = pc
+	s.keyring = kr
+}
+
+var smartContractVestingTotalIntegration = sdk.NewCoins(
+	sdk.NewCoin(utils.BaseDenom, sdkmath.NewInt(3000).MulRaw(1e18)),
+)
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}
+
+// createClawbackVestingAccountForSmartContract converts an existing smart
+// contract account into a ClawbackVestingAccount for integration tests.
+//
+// IMPORTANT - test-only helper.
+//
+// In production this conversion is impossible: x/vesting MsgConvertIntoVestingAccount
+// rejects contract accounts via IsContractAccount. The helper deliberately
+// bypasses that guard by mutating the auth account directly. It MUST NOT be
+// treated as a model for any on-chain flow.
+func (s *liquidSafeSuite) createClawbackVestingAccountForSmartContract(ctx sdk.Context, addr sdk.AccAddress) {
+	funder := sdk.AccAddress(liquidtypes.ModuleName)
+	periodCoin := sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdkmath.NewInt(1000).MulRaw(1e18)))
+	lockupPeriods := sdkvesting.Periods{
+		{Length: 100000, Amount: periodCoin},
+		{Length: 100000, Amount: periodCoin},
+		{Length: 100000, Amount: periodCoin},
+	}
+	vestingPeriods := sdkvesting.Periods{
+		{Length: 0, Amount: smartContractVestingTotalIntegration},
+	}
+
+	existing := s.network.App.AccountKeeper.GetAccount(ctx, addr)
+	Expect(existing).NotTo(BeNil(), "smart-contract account must exist before being wrapped into a vesting account")
+
+	baseAccount := authtypes.NewBaseAccount(
+		existing.GetAddress(),
+		existing.GetPubKey(),
+		existing.GetAccountNumber(),
+		existing.GetSequence(),
+	)
+
+	var codeHashPtr *common.Hash
+	if ethAcc, ok := existing.(*haqqtypes.EthAccount); ok {
+		h := ethAcc.GetCodeHash()
+		codeHashPtr = &h
+	}
+
+	startTime := ctx.BlockTime().Add(-10 * time.Second)
+	clawbackAccount := vestingtypes.NewClawbackVestingAccount(
+		baseAccount, funder, smartContractVestingTotalIntegration, startTime, lockupPeriods, vestingPeriods, codeHashPtr,
+	)
+
+	Expect(haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, addr, smartContractVestingTotalIntegration)).
+		To(Succeed(), "failed to fund Safe vesting balance")
+	s.network.App.AccountKeeper.SetAccount(ctx, clawbackAccount)
+}
+
+var _ = Describe("Liquid Vesting precompile with Gnosis Safe (smart contract wallet)", Ordered, func() {
+	var (
+		s                *liquidSafeSuite
+		safeOwnerOne     keyring.Key
+		safeOwnerTwo     keyring.Key
+		gnosisSafe       evmtypes.CompiledContract
+		gnosisSafeAddr   common.Address
+		proxyFactory     evmtypes.CompiledContract
+		proxyFactoryAddr common.Address
+	)
+
+	// Common balance constants used across the suite. All amounts are in
+	// aISLM (1 ISLM = 1e18 aISLM) to match the on-chain unit.
+	var (
+		islmInitialOwnerFunding = sdkmath.NewInt(1500).MulRaw(1e18)
+		islmTransferToSafe      = sdkmath.NewInt(500).MulRaw(1e18)
+		islmExpectedSafeFree    = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmOwnerTwoBaseline    = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmOwnerOneFloor       = sdkmath.NewInt(999).MulRaw(1e18)
+		islmOwnerOneCeil        = sdkmath.NewInt(1000).MulRaw(1e18)
+		islmVestingTotal        = sdkmath.NewInt(3000).MulRaw(1e18)
+		islmLiquidationAmount   = sdkmath.NewInt(500).MulRaw(1e18)
+	)
+
+	BeforeEach(func() {
+		kr := keyring.New(1)
+		s = new(liquidSafeSuite)
+		s.setupNetwork(kr)
+
+		var err error
+		gnosisSafe, err = safecontracts.LoadGnosisSafeContract()
+		Expect(err).NotTo(HaveOccurred(), "failed to load GnosisSafe singleton contract")
+
+		proxyFactory, err = safecontracts.LoadGnosisSafeProxyFactoryContract()
+		Expect(err).NotTo(HaveOccurred(), "failed to load GnosisSafeProxyFactory contract")
+
+		oneAddr, onePriv := testutiltx.NewAddrKey()
+		safeOwnerOne = keyring.Key{
+			Addr:    oneAddr,
+			AccAddr: sdk.AccAddress(oneAddr.Bytes()),
+			Priv:    onePriv,
+		}
+		twoAddr, twoPriv := testutiltx.NewAddrKey()
+		safeOwnerTwo = keyring.Key{
+			Addr:    twoAddr,
+			AccAddr: sdk.AccAddress(twoAddr.Bytes()),
+			Priv:    twoPriv,
+		}
+
+		Expect(s.network.FundAccountWithBaseDenom(safeOwnerOne.AccAddr, islmInitialOwnerFunding)).
+			To(Succeed(), "failed to fund first Safe owner with 1500 ISLM")
+		Expect(s.network.FundAccountWithBaseDenom(safeOwnerTwo.AccAddr, islmInitialOwnerFunding)).
+			To(Succeed(), "failed to fund second Safe owner with 1500 ISLM")
+
+		deployer := s.keyring.GetKey(0)
+		gnosisSafeAddr, err = s.factory.DeployContract(
+			deployer.Priv,
+			evmtypes.EvmTxArgs{},
+			factory.ContractDeploymentData{Contract: gnosisSafe},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to deploy GnosisSafe singleton")
+		Expect(gnosisSafeAddr).NotTo(Equal(common.Address{}), "GnosisSafe singleton address must be non-zero")
+
+		proxyFactoryAddr, err = s.factory.DeployContract(
+			deployer.Priv,
+			evmtypes.EvmTxArgs{},
+			factory.ContractDeploymentData{Contract: proxyFactory},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to deploy GnosisSafeProxyFactory")
+		Expect(proxyFactoryAddr).NotTo(Equal(common.Address{}), "GnosisSafeProxyFactory address must be non-zero")
+
+		Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after Safe infrastructure deployment")
+	})
+
+	Describe("Safe deployment, funding and native conversion into a ClawbackVestingAccount", func() {
+		It("should fund Safe with 2x500 ISLM and wrap it into a vesting account with 1000 free + 3000 vesting balances", func() {
+			// 0) Owners must start with exactly 1500 ISLM each.
+			ownerOneBefore, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownerOneBefore.Balance.Amount).To(Equal(islmInitialOwnerFunding),
+				"owner1 must start with exactly 1500 ISLM before Safe deployment")
+			ownerTwoBefore, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownerTwoBefore.Balance.Amount).To(Equal(islmInitialOwnerFunding),
+				"owner2 must start with exactly 1500 ISLM before Safe deployment")
+
+			// 1) Deploy a Safe wallet via GnosisSafeProxyFactory.createProxy.
+			//    Threshold = 1 keeps signing simple for downstream test cases.
+			safeSetupData, err := gnosisSafe.ABI.Pack(
+				"setup",
+				[]common.Address{safeOwnerOne.Addr, safeOwnerTwo.Addr},
+				big.NewInt(1),
+				common.Address{}, []byte{},
+				common.Address{}, common.Address{},
+				big.NewInt(0), common.Address{},
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to pack GnosisSafe setup calldata")
+
+			createProxyRes, err := s.factory.ExecuteContractCall(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &proxyFactoryAddr},
+				factory.CallArgs{
+					ContractABI: proxyFactory.ABI,
+					MethodName:  "createProxy",
+					Args:        []interface{}{gnosisSafeAddr, safeSetupData},
+				},
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to broadcast createProxy tx")
+
+			ethRes, err := s.factory.GetEvmTransactionResponseFromTxResult(createProxyRes)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode createProxy tx response")
+
+			// Find the ProxyCreation log emitted by the factory and decode it
+			// to recover the freshly-created Safe wallet address.
+			proxyCreationEvent := proxyFactory.ABI.Events["ProxyCreation"]
+			var proxyCreationLog *evmtypes.Log
+			for i := range ethRes.Logs {
+				l := ethRes.Logs[i]
+				if len(l.Topics) == 0 || l.Topics[0] != proxyCreationEvent.ID.String() {
+					continue
+				}
+				if common.HexToAddress(l.Address) != proxyFactoryAddr {
+					continue
+				}
+				proxyCreationLog = l
+				break
+			}
+			Expect(proxyCreationLog).NotTo(BeNil(), "ProxyCreation event must be emitted by the factory")
+
+			eventInputs, err := proxyCreationEvent.Inputs.Unpack(proxyCreationLog.Data)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode ProxyCreation event payload")
+			Expect(eventInputs).To(HaveLen(2), "unexpected ProxyCreation payload shape")
+			safeWalletAddr, ok := eventInputs[0].(common.Address)
+			Expect(ok).To(BeTrue(), "first ProxyCreation field must be the proxy address")
+			Expect(safeWalletAddr).NotTo(Equal(common.Address{}), "Safe wallet address must be non-zero")
+			Expect(eventInputs[1]).To(Equal(gnosisSafeAddr), "singleton in ProxyCreation must match the deployed GnosisSafe")
+
+			Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after Safe wallet creation")
+
+			// 2) Sanity-check Safe configuration via on-chain getters.
+			_, thrRes, err := s.factory.CallContractAndCheckLogs(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &safeWalletAddr},
+				factory.CallArgs{ContractABI: gnosisSafe.ABI, MethodName: "getThreshold"},
+				testutil.LogCheckArgs{ExpPass: true},
+			)
+			Expect(err).NotTo(HaveOccurred(), "getThreshold call must succeed")
+			thrOut, err := gnosisSafe.ABI.Methods["getThreshold"].Outputs.Unpack(thrRes.Ret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(thrOut).To(HaveLen(1))
+			Expect(thrOut[0]).To(Equal(big.NewInt(1)), "Safe threshold must be 1")
+
+			_, ownersRes, err := s.factory.CallContractAndCheckLogs(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &safeWalletAddr},
+				factory.CallArgs{ContractABI: gnosisSafe.ABI, MethodName: "getOwners"},
+				testutil.LogCheckArgs{ExpPass: true},
+			)
+			Expect(err).NotTo(HaveOccurred(), "getOwners call must succeed")
+			ownersOut, err := gnosisSafe.ABI.Methods["getOwners"].Outputs.Unpack(ownersRes.Ret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownersOut).To(HaveLen(1))
+			owners, ok := ownersOut[0].([]common.Address)
+			Expect(ok).To(BeTrue())
+			Expect(owners).To(HaveLen(2), "Safe must have exactly two owners")
+			Expect(owners).To(ContainElements(safeOwnerOne.Addr, safeOwnerTwo.Addr),
+				"Safe owners must match the configured pair")
+
+			// 3) Each owner sends 500 ISLM to the Safe via direct bank transfer.
+			//    We bypass the EVM here on purpose - the focus of this test is
+			//    the vesting wrap, not the funding mechanics.
+			safeWalletAccAddr := sdk.AccAddress(safeWalletAddr.Bytes())
+			coins500 := sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, islmTransferToSafe))
+			ctx := s.network.GetContext()
+			Expect(s.network.App.BankKeeper.SendCoins(ctx, safeOwnerOne.AccAddr, safeWalletAccAddr, coins500)).
+				To(Succeed(), "owner1 must successfully transfer 500 ISLM to Safe")
+			Expect(s.network.App.BankKeeper.SendCoins(ctx, safeOwnerTwo.AccAddr, safeWalletAccAddr, coins500)).
+				To(Succeed(), "owner2 must successfully transfer 500 ISLM to Safe")
+			Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after owner transfers")
+
+			// 4) Pre-vesting balance assertions.
+			safeBank, err := s.grpcHandler.GetBalance(safeWalletAccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(safeBank.Balance.Amount).To(Equal(islmExpectedSafeFree),
+				"Safe must hold exactly 1000 ISLM after the two 500 ISLM transfers")
+
+			ownerTwoAfterTransfer, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownerTwoAfterTransfer.Balance.Amount).To(Equal(islmOwnerTwoBaseline),
+				"owner2 must have exactly 1000 ISLM (no gas spent - bank.SendCoins is keeper-level)")
+
+			ownerOneAfterTransfer, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneSpent := ownerOneAfterTransfer.Balance.Amount
+			Expect(ownerOneSpent.GT(islmOwnerOneFloor)).To(BeTrue(),
+				"owner1 must have > 999 ISLM (only gas spent on createProxy)")
+			Expect(ownerOneSpent.LT(islmOwnerOneCeil)).To(BeTrue(),
+				"owner1 must have < 1000 ISLM (some aISLM gas was spent on createProxy)")
+
+			// 5) Wrap Safe into a ClawbackVestingAccount via the test-only
+			//    native helper. In production this is impossible: the
+			//    x/vesting MsgConvertIntoVestingAccount keeper rejects
+			//    contract accounts via IsContractAccount. The helper
+			//    deliberately bypasses that guard so we can build the
+			//    "Safe is also a vesting account" fixture required by
+			//    the liquid vesting precompile flow.
+			s.createClawbackVestingAccountForSmartContract(s.network.GetContext(), safeWalletAccAddr)
+			Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after vesting wrap")
+
+			// 6) Post-vesting balance assertions.
+
+			// 6a) Bank balance must be 1000 free + 3000 vesting = 4000 ISLM.
+			expectedSafeBankAfterVesting := islmExpectedSafeFree.Add(islmVestingTotal)
+			safeBankAfter, err := s.grpcHandler.GetBalance(safeWalletAccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(safeBankAfter.Balance.Amount).To(Equal(expectedSafeBankAfterVesting),
+				"Safe bank balance must equal 1000 free + 3000 vesting = 4000 ISLM after wrap")
+
+			// 6b) Spendable balance = bank - locked = 4000 - 3000 = 1000 ISLM.
+			spendable := s.network.App.BankKeeper.SpendableCoin(s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom)
+			Expect(spendable.Amount).To(Equal(islmExpectedSafeFree),
+				"Safe must have exactly 1000 spendable ISLM after vesting wrap")
+
+			// 6c) Auth account is now a ClawbackVestingAccount with the
+			//     expected schedule.
+			acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), safeWalletAccAddr)
+			Expect(acc).NotTo(BeNil(), "Safe auth account must exist after vesting wrap")
+			cba, ok := acc.(*vestingtypes.ClawbackVestingAccount)
+			Expect(ok).To(BeTrue(), "Safe auth account must be a ClawbackVestingAccount")
+			Expect(cba.OriginalVesting.AmountOf(utils.BaseDenom)).To(Equal(islmVestingTotal),
+				"OriginalVesting must equal the configured 3000 ISLM total")
+			Expect(cba.LockupPeriods).To(HaveLen(3), "must have exactly 3 lockup periods")
+			Expect(cba.LockedCoins(s.network.GetContext().BlockTime()).AmountOf(utils.BaseDenom)).
+				To(Equal(islmVestingTotal),
+					"all 3000 ISLM must still be locked (lockup started 10s ago, first period ends in ~100000s)")
+
+			// 6d) The vesting wrap must not affect owner balances.
+			ownerOneFinal, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownerOneFinal.Balance.Amount).To(Equal(ownerOneAfterTransfer.Balance.Amount),
+				"owner1 balance must be unchanged by the native vesting wrap")
+			ownerTwoFinal, err := s.grpcHandler.GetBalance(safeOwnerTwo.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ownerTwoFinal.Balance.Amount).To(Equal(islmOwnerTwoBaseline),
+				"owner2 balance must be unchanged by the native vesting wrap")
+
+			// 7) Execute Safe -> LiquidVesting precompile liquidate(500 ISLM).
+			//
+			// The precompile requires authz whenever the EVM caller (Safe)
+			// differs from tx origin (owner1). Grant it natively here so the
+			// tested action remains the Safe EVM execution path, while setup
+			// stays minimal for this step.
+			liquidateGrant := sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{}))
+			Expect(s.network.App.AuthzKeeper.SaveGrant(
+				s.network.GetContext(),
+				safeWalletAccAddr,
+				safeOwnerOne.AccAddr,
+				liquidateGrant,
+				ptrTime(s.network.GetContext().BlockTime().Add(time.Hour)),
+			)).To(Succeed(), "failed to grant Safe authz to liquidate via precompile")
+
+			liquidVestingModuleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+			moduleBaseBefore := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
+			).Amount
+			safeBaseBeforeLiquidate := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeSpendableBeforeLiquidate := s.network.App.BankKeeper.SpendableCoin(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			ownerOneBeforeLiquidate, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+
+			liquidateCallData, err := s.precompile.ABI.Pack(
+				liquid.LiquidateMethod,
+				safeWalletAddr,
+				safeWalletAddr,
+				islmLiquidationAmount.BigInt(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to pack liquidate call data")
+
+			_, nonceRes, err := s.factory.CallContractAndCheckLogs(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &safeWalletAddr},
+				factory.CallArgs{ContractABI: gnosisSafe.ABI, MethodName: "nonce"},
+				testutil.LogCheckArgs{ExpPass: true},
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to read Safe nonce before liquidate")
+			nonceOut, err := gnosisSafe.ABI.Methods["nonce"].Outputs.Unpack(nonceRes.Ret)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe nonce")
+			nonce, ok := nonceOut[0].(*big.Int)
+			Expect(ok).To(BeTrue(), "Safe nonce output must be *big.Int")
+
+			safeTxGas := big.NewInt(500_000)
+			getTxHashArgs := factory.CallArgs{
+				ContractABI: gnosisSafe.ABI,
+				MethodName:  "getTransactionHash",
+				Args: []interface{}{
+					s.precompile.Address(),
+					big.NewInt(0),
+					liquidateCallData,
+					uint8(0), // CALL
+					safeTxGas,
+					big.NewInt(0),
+					big.NewInt(0),
+					common.Address{},
+					common.Address{},
+					nonce,
+				},
+			}
+			_, txHashRes, err := s.factory.CallContractAndCheckLogs(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &safeWalletAddr},
+				getTxHashArgs,
+				testutil.LogCheckArgs{ExpPass: true},
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to calculate Safe tx hash")
+			txHashOut, err := gnosisSafe.ABI.Methods["getTransactionHash"].Outputs.Unpack(txHashRes.Ret)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe tx hash")
+			Expect(txHashOut).To(HaveLen(1))
+			txHash, ok := txHashOut[0].([32]byte)
+			Expect(ok).To(BeTrue(), "Safe tx hash output must be [32]byte")
+			Expect(txHash).NotTo(Equal([32]byte{}), "Safe tx hash must be non-zero")
+
+			// Safe signature format is {r}{s}{v}. For threshold=1 we use the
+			// approved-hash signature form: v=1 and r=owner1 address.
+			signature := make([]byte, 65)
+			copy(signature[12:32], safeOwnerOne.Addr.Bytes())
+			signature[64] = 1
+
+			execTxRes, err := s.factory.ExecuteContractCall(
+				safeOwnerOne.Priv,
+				evmtypes.EvmTxArgs{To: &safeWalletAddr},
+				factory.CallArgs{
+					ContractABI: gnosisSafe.ABI,
+					MethodName:  "execTransaction",
+					Args: []interface{}{
+						s.precompile.Address(),
+						big.NewInt(0),
+						liquidateCallData,
+						uint8(0), // CALL
+						safeTxGas,
+						big.NewInt(0),
+						big.NewInt(0),
+						common.Address{},
+						common.Address{},
+						signature,
+					},
+				},
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to execute Safe liquidate transaction")
+			execRes, err := s.factory.GetEvmTransactionResponseFromTxResult(execTxRes)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe liquidate tx response")
+			execOut, err := gnosisSafe.ABI.Methods["execTransaction"].Outputs.Unpack(execRes.Ret)
+			Expect(err).NotTo(HaveOccurred(), "failed to decode Safe execTransaction output")
+			Expect(execOut).To(HaveLen(1))
+			execSuccess, ok := execOut[0].(bool)
+			Expect(ok).To(BeTrue(), "execTransaction output must be bool")
+			Expect(execSuccess).To(BeTrue(), "Safe liquidate execTransaction must succeed")
+
+			executionSuccessEvent := gnosisSafe.ABI.Events["ExecutionSuccess"]
+			executionSuccessFound := false
+			for i := range execRes.Logs {
+				l := execRes.Logs[i]
+				if len(l.Topics) == 0 || l.Topics[0] != executionSuccessEvent.ID.String() {
+					continue
+				}
+				if common.HexToAddress(l.Address) != safeWalletAddr {
+					continue
+				}
+				executionSuccessFound = true
+				break
+			}
+			Expect(executionSuccessFound).To(BeTrue(), "Safe must emit ExecutionSuccess for liquidate")
+			Expect(s.network.NextBlock()).To(Succeed(), "failed to advance block after Safe liquidate")
+
+			// 8) Post-liquidation invariants.
+			ownerOneAfterLiquidate, err := s.grpcHandler.GetBalance(safeOwnerOne.AccAddr, utils.BaseDenom)
+			Expect(err).NotTo(HaveOccurred())
+			ownerOneLiquidateSpend := ownerOneBeforeLiquidate.Balance.Amount.Sub(ownerOneAfterLiquidate.Balance.Amount)
+			Expect(ownerOneLiquidateSpend.IsNegative()).To(BeFalse(), "owner1 balance must not increase after Safe liquidate")
+			Expect(ownerOneLiquidateSpend.LTE(sdkmath.NewInt(1).MulRaw(1e18))).To(BeTrue(),
+				"owner1 must spend no more than 1 ISLM on Safe liquidate gas")
+
+			safeBaseAfterLiquidate := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeSpendableAfterLiquidate := s.network.App.BankKeeper.SpendableCoin(
+				s.network.GetContext(), safeWalletAccAddr, utils.BaseDenom,
+			).Amount
+			safeLockedAfterLiquidate := safeBaseAfterLiquidate.Sub(safeSpendableAfterLiquidate)
+			moduleBaseAfter := s.network.App.BankKeeper.GetBalance(
+				s.network.GetContext(), liquidVestingModuleAddr, utils.BaseDenom,
+			).Amount
+
+			liquidDenom := ""
+			liquidAmount := sdkmath.ZeroInt()
+			for _, coin := range s.network.App.BankKeeper.GetAllBalances(s.network.GetContext(), safeWalletAccAddr) {
+				if strings.HasPrefix(coin.Denom, "aLIQUID") {
+					liquidDenom = coin.Denom
+					liquidAmount = coin.Amount
+					break
+				}
+			}
+
+			GinkgoWriter.Printf(
+				"liquidate balances: safeBaseBefore=%s safeBaseAfter=%s spendableBefore=%s spendableAfter=%s lockedAfter=%s moduleBefore=%s moduleAfter=%s liquidDenom=%s liquidAmount=%s\n",
+				safeBaseBeforeLiquidate.String(),
+				safeBaseAfterLiquidate.String(),
+				safeSpendableBeforeLiquidate.String(),
+				safeSpendableAfterLiquidate.String(),
+				safeLockedAfterLiquidate.String(),
+				moduleBaseBefore.String(),
+				moduleBaseAfter.String(),
+				liquidDenom,
+				liquidAmount.String(),
+			)
+
+			Expect(safeSpendableAfterLiquidate).To(Equal(islmExpectedSafeFree),
+				"Safe spendable ISLM must remain exactly 1000 after liquidating locked vesting")
+			Expect(safeLockedAfterLiquidate).To(Equal(islmVestingTotal.Sub(islmLiquidationAmount)),
+				"Safe locked vesting ISLM must be 2500 after liquidating 500")
+			Expect(safeBaseBeforeLiquidate.Sub(safeBaseAfterLiquidate)).To(Equal(islmLiquidationAmount),
+				"Safe base ISLM bank balance must decrease exactly by the liquidated amount")
+			Expect(moduleBaseAfter.Sub(moduleBaseBefore)).To(Equal(islmLiquidationAmount),
+				"liquid vesting module ISLM balance must increase exactly by the liquidated amount")
+			Expect(safeBaseBeforeLiquidate.Add(moduleBaseBefore)).To(Equal(safeBaseAfterLiquidate.Add(moduleBaseAfter)),
+				"Safe ISLM decrease must be fully accounted for by the liquid vesting module increase")
+			Expect(liquidDenom).NotTo(BeEmpty(), "Safe must receive a liquid vesting denom")
+			Expect(liquidAmount).To(Equal(islmLiquidationAmount),
+				"Safe must receive exactly 500 ISLM-equivalent liquid tokens")
+			Expect(s.network.App.BankKeeper.GetSupply(s.network.GetContext(), liquidDenom).Amount).To(Equal(islmLiquidationAmount),
+				"liquid token supply must equal the minted amount; no extra liquid tokens may appear")
+
+			Expect(safeSpendableBeforeLiquidate).To(Equal(safeSpendableAfterLiquidate),
+				"liquidating locked vesting must not change Safe spendable ISLM")
+		})
+	})
+})

--- a/precompiles/liquid/run_test.go
+++ b/precompiles/liquid/run_test.go
@@ -107,6 +107,26 @@ func (s *PrecompileTestSuite) TestRun() {
 			expPass:  false,
 		},
 		{
+			// Symmetric kill-switch for the Redeem dispatcher: a static call
+			// (readOnly = true) must be rejected upfront by RunSetup before
+			// any keeper or mirror logic is reached. Without this row, only
+			// Liquidate's read-only protection is exercised.
+			name: "fail - redeem read-only",
+			malleate: func(_ sdk.Context) []byte {
+				input, err := s.precompile.Pack(
+					liquid.RedeemMethod,
+					s.keyring.GetAddr(0),
+					s.keyring.GetAddr(0),
+					liquidtypes.DenomBaseNameFromID(0),
+					big.NewInt(1_000_000),
+				)
+				s.Require().NoError(err)
+				return input
+			},
+			readOnly: true,
+			expPass:  false,
+		},
+		{
 			name: "fail - liquidate with wrong origin",
 			malleate: func(_ sdk.Context) []byte {
 				// Use a different address from the keyring sender (index 0) as the "from"
@@ -154,6 +174,34 @@ func (s *PrecompileTestSuite) TestRun() {
 					big.NewInt(1_000_000),
 				)
 				s.Require().NoError(err)
+				return input
+			},
+			readOnly: false,
+			expPass:  false,
+		},
+		{
+			// Tier 3 defence: input shorter than the 4-byte ABI selector
+			// must be rejected by the dispatcher without invoking any
+			// method. This is the smallest "garbage input" attack surface.
+			name: "fail - input shorter than 4-byte selector",
+			malleate: func(_ sdk.Context) []byte {
+				return []byte{0x12, 0x34, 0x56}
+			},
+			readOnly: false,
+			expPass:  false,
+		},
+		{
+			// Tier 3 defence: a valid Liquidate selector followed by a
+			// truncated args payload must be rejected by ABI unpack
+			// inside Run, not bubble through to the keeper. The selector
+			// is computed below from the method ID so the test cannot
+			// drift if the ABI changes.
+			name: "fail - liquidate selector with truncated args",
+			malleate: func(_ sdk.Context) []byte {
+				selector := s.precompile.Methods[liquid.LiquidateMethod].ID
+				input := make([]byte, 0, len(selector)+8)
+				input = append(input, selector...)
+				input = append(input, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08)
 				return input
 			},
 			readOnly: false,

--- a/precompiles/liquid/tx.go
+++ b/precompiles/liquid/tx.go
@@ -3,10 +3,12 @@ package liquid
 import (
 	"fmt"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 
+	cmn "github.com/haqq-network/haqq/precompiles/common"
 	"github.com/haqq-network/haqq/x/evm/core/vm"
 	liquidkeeper "github.com/haqq-network/haqq/x/liquidvesting/keeper"
 )
@@ -18,9 +20,51 @@ const (
 	RedeemMethod = "redeem"
 )
 
+// mirrorBankBaseDeltaIntoStateDB syncs the bank delta of the EVM gas denom (aISLM)
+// produced by a keeper call into the EVM StateDB journal when the precompile is
+// invoked from another contract (caller != origin).
+//
+// Why this is needed:
+//   - Liquidate/Redeem move aISLM through bankKeeper.SendCoinsFromAccount/ModuleTo* directly.
+//     Those calls update the SDK bank state but do not touch the EVM journal.
+//   - On EVM tx commit, x/evm reconciles native EVM account balances against the
+//     SDK bank for accounts touched by the EVM journal. If the contract account that
+//     was actually debited/credited in bank is not in the journal, its EVM-side balance
+//     is left unchanged, while bank already reflects the move - leading to a state
+//     mismatch and effectively "phantom" coins on the EVM side.
+//   - When caller == origin (EOA), x/evm intentionally skips reconciling the origin's
+//     balance for these direct keeper movements, so no journal entry is required.
+//
+// baseBefore must be sampled immediately before the keeper/msg work; the resulting
+// delta matches the actual bank movement (which may differ from the nominal msg amount,
+// e.g. for Redeem the credit on `to` equals the unlocked principal that round-trips
+// through the module account).
+func (p *Precompile) mirrorBankBaseDeltaIntoStateDB(
+	ctx sdk.Context,
+	isCallerOrigin bool,
+	addr sdk.AccAddress,
+	baseBefore sdkmath.Int,
+) {
+	if isCallerOrigin {
+		return
+	}
+	netBaseDelta := baseBefore.Sub(p.keeper.BaseDenomBankBalance(ctx, addr))
+	if netBaseDelta.IsZero() {
+		return
+	}
+	hexAddr := common.BytesToAddress(addr.Bytes())
+	if netBaseDelta.IsNegative() {
+		// Bank balance grew: account was credited - mirror as Add.
+		p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.Neg().BigInt(), cmn.Add))
+		return
+	}
+	// Bank balance shrank: account was debited - mirror as Sub.
+	p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.BigInt(), cmn.Sub))
+}
+
 // Liquidate executes the liquidvesting Liquidate message.
 // It supports authorization when the caller is not the origin account.
-func (p Precompile) Liquidate(
+func (p *Precompile) Liquidate(
 	ctx sdk.Context,
 	origin common.Address,
 	contract *vm.Contract,
@@ -51,6 +95,8 @@ func (p Precompile) Liquidate(
 
 	// isCallerSender is true when the contract caller is the same as the sender
 	isCallerSender := contract.CallerAddress == sender
+	// isCallerOrigin is true when the contract caller is the same as the origin
+	isCallerOrigin := contract.CallerAddress == origin
 
 	// Ensure the logical sender matches the origin when going through a contract.
 	if !isCallerSender && origin != sender {
@@ -58,7 +104,7 @@ func (p Precompile) Liquidate(
 	}
 
 	// Check and accept authorization if needed
-	if contract.CallerAddress != origin {
+	if !isCallerOrigin {
 		msgURL := sdk.MsgTypeURL(msg)
 		authzGrant, expiration := p.AuthzKeeper.GetAuthorization(ctx, callerAddr, originAddr, msgURL)
 		if authzGrant == nil {
@@ -86,12 +132,22 @@ func (p Precompile) Liquidate(
 		}
 	}
 
+	// Snapshot the bank balance of the debited account (liquidateFrom) BEFORE the
+	// keeper call so the EVM-side mirror can replay the exact aISLM movement that
+	// SendCoinsFromAccountToModule performs inside Liquidate.
+	liquidateFromAccAddr := sdk.MustAccAddressFromBech32(msg.LiquidateFrom)
+	baseBefore := p.keeper.BaseDenomBankBalance(ctx, liquidateFromAccAddr)
+
 	// Execute the message using the message server.
 	msgSrv := liquidkeeper.NewMsgServerImpl(p.keeper)
 	res, err := msgSrv.Liquidate(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
+
+	// Mirror the bank delta on liquidateFrom into the EVM StateDB journal so that
+	// the EVM commit sees the contract caller's aISLM balance as actually debited.
+	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, liquidateFromAccAddr, baseBefore)
 
 	minted := res.Minted.Amount.BigInt()
 	erc20Addr := common.HexToAddress(res.ContractAddr)
@@ -106,7 +162,7 @@ func (p Precompile) Liquidate(
 // Redeem executes the liquidvesting Redeem message.
 // It MUST always be executed via authorization, regardless of caller/origin,
 // since it needs to transfer liquid ERC20 representation back into native coins.
-func (p Precompile) Redeem(
+func (p *Precompile) Redeem(
 	ctx sdk.Context,
 	origin common.Address,
 	contract *vm.Contract,
@@ -137,6 +193,8 @@ func (p Precompile) Redeem(
 
 	// isCallerSender is true when the contract caller is the same as the sender
 	isCallerSender := contract.CallerAddress == sender
+	// isCallerOrigin is true when the contract caller is the same as the origin
+	isCallerOrigin := contract.CallerAddress == origin
 
 	// If the contract caller is not the same as the sender, the sender must be the origin
 	if !isCallerSender && origin != sender {
@@ -144,7 +202,7 @@ func (p Precompile) Redeem(
 	}
 
 	// Check and accept authorization if needed
-	if contract.CallerAddress != origin {
+	if !isCallerOrigin {
 		msgURL := sdk.MsgTypeURL(msg)
 
 		// Require an authz grant from the origin (granter) to the contract caller (grantee).
@@ -174,11 +232,33 @@ func (p Precompile) Redeem(
 		}
 	}
 
+	// Snapshot the bank balances of both bank-touching counterparties BEFORE the
+	// keeper call so the EVM-side mirror can replay the exact aISLM movement that
+	// Redeem performs internally:
+	//   - redeemFrom is debited the liquid (aLIQUID*) denom, which is NOT the EVM
+	//     gas denom, so its base-denom balance is unchanged - sampling it lets the
+	//     mirror no-op for that side without special-casing.
+	//   - redeemTo is credited the unlocked principal in aISLM coming from the
+	//     liquidvesting module account; this is the credit we must propagate to
+	//     the EVM journal when the call originates from a contract.
+	redeemFromAccAddr := sdk.MustAccAddressFromBech32(msg.RedeemFrom)
+	redeemToAccAddr := sdk.MustAccAddressFromBech32(msg.RedeemTo)
+	fromBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemFromAccAddr)
+	toBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemToAccAddr)
+
 	// Execute the message using the message server.
 	msgSrv := liquidkeeper.NewMsgServerImpl(p.keeper)
 	if _, err := msgSrv.Redeem(ctx, msg); err != nil {
 		return nil, err
 	}
+
+	// Mirror the bank deltas into the EVM StateDB journal so that the EVM commit
+	// sees the contract caller's aISLM balance as actually credited/debited.
+	// AddBalanceChangeEntries (rather than SetBalanceChangeEntries) is used so the
+	// two entries coexist when redeemFrom == redeemTo or when both sides happen
+	// to move base denom (e.g. through a future hook on the from side).
+	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, redeemFromAccAddr, fromBaseBefore)
+	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, redeemToAccAddr, toBaseBefore)
 
 	if err := p.EmitRedeemEvent(ctx, stateDB, sender, common.HexToAddress(msg.RedeemTo), msg.Amount.Denom, msg.Amount.Amount.BigInt()); err != nil {
 		return nil, err

--- a/precompiles/liquid/tx.go
+++ b/precompiles/liquid/tx.go
@@ -20,8 +20,16 @@ const (
 	RedeemMethod = "redeem"
 )
 
-// mirrorBankBaseDeltaIntoStateDB syncs the bank delta of the EVM gas denom (aISLM)
-// produced by a keeper call into the EVM StateDB journal when the precompile is
+// bankBaseSnapshot pairs an account with its sampled base-denom (aISLM) bank
+// balance, captured immediately before a keeper call. It is the input unit
+// for mirrorBankBaseDeltasIntoStateDB.
+type bankBaseSnapshot struct {
+	addr       sdk.AccAddress
+	baseBefore sdkmath.Int
+}
+
+// mirrorBankBaseDeltasIntoStateDB mirrors per-account bank deltas of the EVM
+// gas denom (aISLM) into the EVM StateDB journal when the precompile is
 // invoked from another contract (caller != origin).
 //
 // Why this is needed:
@@ -35,31 +43,48 @@ const (
 //   - When caller == origin (EOA), x/evm intentionally skips reconciling the origin's
 //     balance for these direct keeper movements, so no journal entry is required.
 //
-// baseBefore must be sampled immediately before the keeper/msg work; the resulting
-// delta matches the actual bank movement (which may differ from the nominal msg amount,
-// e.g. for Redeem the credit on `to` equals the unlocked principal that round-trips
-// through the module account).
-func (p *Precompile) mirrorBankBaseDeltaIntoStateDB(
+// Each snapshot.baseBefore must be sampled immediately before the keeper/msg work;
+// the resulting delta matches the actual bank movement (which may differ from the
+// nominal msg amount, e.g. for Redeem the credit on `to` equals the unlocked
+// principal that round-trips through the module account).
+//
+// IMPORTANT - duplicate accounts must be mirrored exactly once. A given account
+// can appear in multiple roles in the same call (typical case: redeemFrom ==
+// redeemTo when an account redeems back into itself). The function
+// deduplicates snapshots by address bech32, so a single account contributes a
+// single Sub/Add journal entry whose magnitude is its net post-keeper bank
+// delta. Without this, x/evm would over-credit/-debit the account at commit
+// (each repeated journal entry triggers another reconciliation pass), which is
+// exactly the phantom-coin failure mode this helper exists to prevent.
+func (p *Precompile) mirrorBankBaseDeltasIntoStateDB(
 	ctx sdk.Context,
 	isCallerOrigin bool,
-	addr sdk.AccAddress,
-	baseBefore sdkmath.Int,
+	snapshots ...bankBaseSnapshot,
 ) {
 	if isCallerOrigin {
 		return
 	}
-	netBaseDelta := baseBefore.Sub(p.keeper.BaseDenomBankBalance(ctx, addr))
-	if netBaseDelta.IsZero() {
-		return
+	seen := make(map[string]struct{}, len(snapshots))
+	for _, s := range snapshots {
+		key := s.addr.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		netBaseDelta := s.baseBefore.Sub(p.keeper.BaseDenomBankBalance(ctx, s.addr))
+		if netBaseDelta.IsZero() {
+			continue
+		}
+		hexAddr := common.BytesToAddress(s.addr.Bytes())
+		if netBaseDelta.IsNegative() {
+			// Bank balance grew: account was credited - mirror as Add.
+			p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.Neg().BigInt(), cmn.Add))
+			continue
+		}
+		// Bank balance shrank: account was debited - mirror as Sub.
+		p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.BigInt(), cmn.Sub))
 	}
-	hexAddr := common.BytesToAddress(addr.Bytes())
-	if netBaseDelta.IsNegative() {
-		// Bank balance grew: account was credited - mirror as Add.
-		p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.Neg().BigInt(), cmn.Add))
-		return
-	}
-	// Bank balance shrank: account was debited - mirror as Sub.
-	p.AddBalanceChangeEntries(cmn.NewBalanceChangeEntry(hexAddr, netBaseDelta.BigInt(), cmn.Sub))
 }
 
 // Liquidate executes the liquidvesting Liquidate message.
@@ -132,11 +157,13 @@ func (p *Precompile) Liquidate(
 		}
 	}
 
-	// Snapshot the bank balance of the debited account (liquidateFrom) BEFORE the
-	// keeper call so the EVM-side mirror can replay the exact aISLM movement that
-	// SendCoinsFromAccountToModule performs inside Liquidate.
+	// Snapshot the bank balance of the debited account (liquidateFrom) BEFORE
+	// the keeper call so the EVM-side mirror can replay the exact aISLM movement
+	// that SendCoinsFromAccountToModule performs inside Liquidate. liquidateTo
+	// only receives aLIQUID*, which is not the EVM gas denom, so there is no
+	// base-denom delta to mirror on it.
 	liquidateFromAccAddr := sdk.MustAccAddressFromBech32(msg.LiquidateFrom)
-	baseBefore := p.keeper.BaseDenomBankBalance(ctx, liquidateFromAccAddr)
+	liquidateFromBaseBefore := p.keeper.BaseDenomBankBalance(ctx, liquidateFromAccAddr)
 
 	// Execute the message using the message server.
 	msgSrv := liquidkeeper.NewMsgServerImpl(p.keeper)
@@ -145,9 +172,12 @@ func (p *Precompile) Liquidate(
 		return nil, err
 	}
 
-	// Mirror the bank delta on liquidateFrom into the EVM StateDB journal so that
-	// the EVM commit sees the contract caller's aISLM balance as actually debited.
-	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, liquidateFromAccAddr, baseBefore)
+	// Mirror the bank delta on liquidateFrom into the EVM StateDB journal so
+	// that the EVM commit sees the contract caller's aISLM balance as actually
+	// debited.
+	p.mirrorBankBaseDeltasIntoStateDB(ctx, isCallerOrigin,
+		bankBaseSnapshot{addr: liquidateFromAccAddr, baseBefore: liquidateFromBaseBefore},
+	)
 
 	minted := res.Minted.Amount.BigInt()
 	erc20Addr := common.HexToAddress(res.ContractAddr)
@@ -232,19 +262,26 @@ func (p *Precompile) Redeem(
 		}
 	}
 
-	// Snapshot the bank balances of both bank-touching counterparties BEFORE the
-	// keeper call so the EVM-side mirror can replay the exact aISLM movement that
-	// Redeem performs internally:
-	//   - redeemFrom is debited the liquid (aLIQUID*) denom, which is NOT the EVM
-	//     gas denom, so its base-denom balance is unchanged - sampling it lets the
-	//     mirror no-op for that side without special-casing.
+	// Snapshot the bank balances of both bank-touching counterparties BEFORE
+	// the keeper call so the EVM-side mirror can replay the exact aISLM
+	// movement that Redeem performs internally:
+	//   - redeemFrom is debited the liquid (aLIQUID*) denom, which is NOT the
+	//     EVM gas denom, so its base-denom balance is unchanged in the
+	//     redeemFrom != redeemTo case - sampling it lets the mirror no-op for
+	//     that side without special-casing.
 	//   - redeemTo is credited the unlocked principal in aISLM coming from the
-	//     liquidvesting module account; this is the credit we must propagate to
-	//     the EVM journal when the call originates from a contract.
+	//     liquidvesting module account; this is the credit we must propagate
+	//     to the EVM journal when the call originates from a contract.
+	//
+	// When redeemFrom == redeemTo (typical "self-redeem"), both snapshots
+	// resolve to the same account; the dedup logic in
+	// mirrorBankBaseDeltasIntoStateDB ensures the net delta is mirrored
+	// exactly once. Without that dedup, x/evm's commit-time reconciliation
+	// would replay the credit twice and double the bank balance growth.
 	redeemFromAccAddr := sdk.MustAccAddressFromBech32(msg.RedeemFrom)
 	redeemToAccAddr := sdk.MustAccAddressFromBech32(msg.RedeemTo)
-	fromBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemFromAccAddr)
-	toBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemToAccAddr)
+	redeemFromBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemFromAccAddr)
+	redeemToBaseBefore := p.keeper.BaseDenomBankBalance(ctx, redeemToAccAddr)
 
 	// Execute the message using the message server.
 	msgSrv := liquidkeeper.NewMsgServerImpl(p.keeper)
@@ -252,13 +289,10 @@ func (p *Precompile) Redeem(
 		return nil, err
 	}
 
-	// Mirror the bank deltas into the EVM StateDB journal so that the EVM commit
-	// sees the contract caller's aISLM balance as actually credited/debited.
-	// AddBalanceChangeEntries (rather than SetBalanceChangeEntries) is used so the
-	// two entries coexist when redeemFrom == redeemTo or when both sides happen
-	// to move base denom (e.g. through a future hook on the from side).
-	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, redeemFromAccAddr, fromBaseBefore)
-	p.mirrorBankBaseDeltaIntoStateDB(ctx, isCallerOrigin, redeemToAccAddr, toBaseBefore)
+	p.mirrorBankBaseDeltasIntoStateDB(ctx, isCallerOrigin,
+		bankBaseSnapshot{addr: redeemFromAccAddr, baseBefore: redeemFromBaseBefore},
+		bankBaseSnapshot{addr: redeemToAccAddr, baseBefore: redeemToBaseBefore},
+	)
 
 	if err := p.EmitRedeemEvent(ctx, stateDB, sender, common.HexToAddress(msg.RedeemTo), msg.Amount.Denom, msg.Amount.Amount.BigInt()); err != nil {
 		return nil, err

--- a/precompiles/liquid/tx_test.go
+++ b/precompiles/liquid/tx_test.go
@@ -10,12 +10,14 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	sdkauthz "github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/ethereum/go-ethereum/common"
 
 	cmn "github.com/haqq-network/haqq/precompiles/common"
 	"github.com/haqq-network/haqq/precompiles/liquid"
 	"github.com/haqq-network/haqq/precompiles/testutil"
 	haqqtestutil "github.com/haqq-network/haqq/testutil"
 	utiltx "github.com/haqq-network/haqq/testutil/tx"
+	haqqtypes "github.com/haqq-network/haqq/types"
 	"github.com/haqq-network/haqq/utils"
 	liquidtypes "github.com/haqq-network/haqq/x/liquidvesting/types"
 	vestingtypes "github.com/haqq-network/haqq/x/vesting/types"
@@ -45,6 +47,79 @@ func (s *PrecompileTestSuite) createClawbackVestingAccount(ctx sdk.Context, addr
 	)
 	err := haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, addr, vestingAmount)
 	s.Require().NoError(err)
+	s.network.App.AccountKeeper.SetAccount(ctx, clawbackAccount)
+}
+
+// smartContractVestingTotal is the total amount used by the smart-contract
+// vesting test factory: 3000 ISLM = 3000 * 1e18 aISLM.
+var smartContractVestingTotal = sdk.NewCoins(
+	sdk.NewCoin(utils.BaseDenom, sdkmath.NewInt(3000).MulRaw(1e18)),
+)
+
+// createClawbackVestingAccountForSmartContract converts an existing on-chain
+// account at addr (typically a deployed smart-contract wallet such as a Gnosis
+// Safe proxy) into a ClawbackVestingAccount with the schedule used by Safe
+// integration tests: 3 lockup periods of 1000 ISLM each (3000 ISLM total) and
+// a single instant vesting period for 3000 ISLM. The lockup starts 10 seconds
+// in the past, so all 3000 ISLM are still locked at block time.
+//
+// IMPORTANT - test-only helper.
+//
+// In production this conversion is impossible: x/vesting MsgConvertIntoVestingAccount
+// rejects contract accounts (see the IsContractAccount guard in
+// x/vesting/keeper/msg_server.go). The helper deliberately bypasses that
+// guard by mutating the auth account directly. It MUST NOT be treated as a
+// model for any on-chain flow - it only exists to build a test fixture
+// where a smart-contract wallet behaves as if it were under a vesting
+// schedule, so the liquid vesting precompile can be exercised end-to-end
+// against a Safe-shaped sender.
+//
+// Side effects:
+//   - mints 3000 ISLM into addr via testutil.FundAccount (on top of any
+//     pre-existing balance);
+//   - replaces the auth account at addr with a ClawbackVestingAccount that
+//     preserves the original BaseAccount metadata (AccountNumber, Sequence,
+//     PubKey) and the original CodeHash if addr was an EthAccount, so the
+//     contract code at that address remains callable through the EVM.
+func (s *PrecompileTestSuite) createClawbackVestingAccountForSmartContract(
+	ctx sdk.Context, addr sdk.AccAddress,
+) {
+	funder := sdk.AccAddress(liquidtypes.ModuleName)
+	periodCoin := sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdkmath.NewInt(1000).MulRaw(1e18)))
+	lockupPeriods := sdkvesting.Periods{
+		{Length: 100000, Amount: periodCoin},
+		{Length: 100000, Amount: periodCoin},
+		{Length: 100000, Amount: periodCoin},
+	}
+	vestingPeriods := sdkvesting.Periods{
+		{Length: 0, Amount: smartContractVestingTotal},
+	}
+
+	existing := s.network.App.AccountKeeper.GetAccount(ctx, addr)
+	s.Require().NotNil(existing, "smart-contract account must exist before being wrapped into a vesting account")
+
+	baseAccount := authtypes.NewBaseAccount(
+		existing.GetAddress(),
+		existing.GetPubKey(),
+		existing.GetAccountNumber(),
+		existing.GetSequence(),
+	)
+
+	// Preserve the EVM code reference. ClawbackVestingAccount stores its own
+	// CodeHash field, so we must carry it over from the EthAccount to keep
+	// the contract callable via the EVM.
+	var codeHashPtr *common.Hash
+	if ethAcc, ok := existing.(*haqqtypes.EthAccount); ok {
+		h := ethAcc.GetCodeHash()
+		codeHashPtr = &h
+	}
+
+	startTime := ctx.BlockTime().Add(-10 * time.Second)
+	clawbackAccount := vestingtypes.NewClawbackVestingAccount(
+		baseAccount, funder, smartContractVestingTotal, startTime, lockupPeriods, vestingPeriods, codeHashPtr,
+	)
+
+	s.Require().NoError(haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, addr, smartContractVestingTotal))
 	s.network.App.AccountKeeper.SetAccount(ctx, clawbackAccount)
 }
 

--- a/precompiles/liquid/tx_test.go
+++ b/precompiles/liquid/tx_test.go
@@ -666,3 +666,1278 @@ func (s *PrecompileTestSuite) TestRedeemViaContract() {
 	})
 	s.Require().NoError(err)
 }
+
+// ---------------------------------------------------------------------------
+// Mirror / state-consistency tests: explicit bank-delta assertions for the
+// EOA-driven Liquidate / Redeem paths. These complement the Safe integration
+// suite: there caller != origin and the mirror MUST fire; here caller ==
+// origin and the mirror MUST be a no-op. A regression in either direction
+// (mirror leaks for EOA, or mirror is silently skipped for contract) shows up
+// here as a wrong post-call bank balance.
+// ---------------------------------------------------------------------------
+
+// TestLiquidateEOABankDeltas verifies that an EOA-driven Liquidate produces
+// exactly the expected bank deltas on liquidateFrom (debited base denom),
+// liquidateTo (credited liquid denom only) and the liquid vesting module
+// (credited base denom). The mirror is a no-op on the caller==origin path,
+// so any over- or under-counting would show up as a wrong bank balance.
+func (s *PrecompileTestSuite) TestLiquidateEOABankDeltas() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	// liquidateFrom is a fresh vesting account; liquidateTo is a distinct
+	// keyring EOA so we also exercise the from != to branch on the EOA path.
+	fromEvmAddr := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(fromEvmAddr.Bytes())
+	toEvmAddr := s.keyring.GetAddr(1)
+	toAccAddr := sdk.AccAddress(toEvmAddr.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	toBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	toLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidDenom).Amount
+
+	amount := sdkmath.NewInt(1_000_000)
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, fromEvmAddr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, fromEvmAddr, contract, s.network.GetStateDB(), &method, []any{
+		fromEvmAddr, toEvmAddr, amount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	fromBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	toBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount
+	moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	toLiquidAfter := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidDenom).Amount
+
+	s.Require().Equal(amount, fromBaseBefore.Sub(fromBaseAfter),
+		"liquidateFrom base must decrease by exactly the liquidated amount on the EOA path")
+	s.Require().Equal(toBaseBefore, toBaseAfter,
+		"liquidateTo base must NOT change (it only receives the liquid denom)")
+	s.Require().Equal(amount, moduleBaseAfter.Sub(moduleBaseBefore),
+		"module base must increase by exactly the liquidated amount")
+	s.Require().Equal(amount, toLiquidAfter.Sub(toLiquidBefore),
+		"liquidateTo must receive exactly the freshly-minted liquid amount")
+	s.Require().Equal(amount, s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount,
+		"liquid token supply must equal the freshly-minted amount; no extra liquid tokens may appear")
+	s.Require().Equal(fromBaseBefore.Add(moduleBaseBefore), fromBaseAfter.Add(moduleBaseAfter),
+		"base-denom conservation: from's debit must be fully accounted for by module's credit")
+}
+
+// TestRedeemEOASelfBankDeltas exercises the EOA self-redeem path
+// (caller == origin AND redeemFrom == redeemTo). It is the EOA-side regression
+// for the dedup logic in mirrorBankBaseDeltasIntoStateDB - on this path the
+// mirror MUST be a no-op (because caller == origin), and the dedup never
+// matters; but if a future change accidentally enables the mirror for
+// caller==origin, this test would catch the resulting double-credit.
+func (s *PrecompileTestSuite) TestRedeemEOASelfBankDeltas() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	fromEvmAddr := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(fromEvmAddr.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	liquidateAmount := sdkmath.NewInt(1_000_000)
+	redeemAmount := sdkmath.NewInt(500_000)
+
+	// Liquidate first so we have liquid tokens to redeem to ourselves.
+	liquidateMethod := s.precompile.Methods[liquid.LiquidateMethod]
+	liqContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, fromEvmAddr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, fromEvmAddr, liqContract, s.network.GetStateDB(), &liquidateMethod, []any{
+		fromEvmAddr, fromEvmAddr, liquidateAmount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	fromLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	supplyBefore := s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount
+
+	redeemMethod := s.precompile.Methods[liquid.RedeemMethod]
+	redContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, fromEvmAddr, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, fromEvmAddr, redContract, s.network.GetStateDB(), &redeemMethod, []any{
+		fromEvmAddr, fromEvmAddr, liquidDenom, redeemAmount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	fromBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	fromLiquidAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount
+	moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	supplyAfter := s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount
+
+	s.Require().Equal(redeemAmount, fromBaseAfter.Sub(fromBaseBefore),
+		"self-redeem must credit redeemFrom exactly once (dedup regression: a double-mirror would show +2x)")
+	s.Require().Equal(redeemAmount, fromLiquidBefore.Sub(fromLiquidAfter),
+		"self-redeem must burn exactly the redeemed liquid amount from the holder")
+	s.Require().Equal(redeemAmount, moduleBaseBefore.Sub(moduleBaseAfter),
+		"module base must decrease by exactly the redeemed amount")
+	s.Require().Equal(redeemAmount, supplyBefore.Sub(supplyAfter),
+		"liquid supply must decrease by exactly the redeemed amount via burn")
+	s.Require().Equal(fromBaseBefore.Add(moduleBaseBefore), fromBaseAfter.Add(moduleBaseAfter),
+		"base-denom conservation: module's debit must be fully accounted for by self-redeemer's credit")
+}
+
+// TestRedeemEOACrossAccountBankDeltas exercises the EOA cross-account redeem
+// path (caller == origin, redeemFrom != redeemTo). It pins down that on the
+// EOA path the keeper still routes the principal to redeemTo, redeemFrom
+// loses only the liquid denom, and no extra entries leak in either direction.
+func (s *PrecompileTestSuite) TestRedeemEOACrossAccountBankDeltas() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	fromEvmAddr := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(fromEvmAddr.Bytes())
+	toEvmAddr := s.keyring.GetAddr(1)
+	toAccAddr := sdk.AccAddress(toEvmAddr.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	liquidateAmount := sdkmath.NewInt(1_000_000)
+	redeemAmount := sdkmath.NewInt(400_000)
+
+	// Liquidate the vesting principal to fromEvmAddr so we have aLIQUID0
+	// available on the redeemFrom side.
+	liquidateMethod := s.precompile.Methods[liquid.LiquidateMethod]
+	liqContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, fromEvmAddr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, fromEvmAddr, liqContract, s.network.GetStateDB(), &liquidateMethod, []any{
+		fromEvmAddr, fromEvmAddr, liquidateAmount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	fromLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount
+	toBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	supplyBefore := s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount
+
+	redeemMethod := s.precompile.Methods[liquid.RedeemMethod]
+	redContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, fromEvmAddr, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, fromEvmAddr, redContract, s.network.GetStateDB(), &redeemMethod, []any{
+		fromEvmAddr, toEvmAddr, liquidDenom, redeemAmount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	fromBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	fromLiquidAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount
+	toBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount
+	moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	supplyAfter := s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount
+
+	s.Require().Equal(fromBaseBefore, fromBaseAfter,
+		"cross-account redeem must NOT change redeemFrom base (only the liquid denom moves on this side)")
+	s.Require().Equal(redeemAmount, fromLiquidBefore.Sub(fromLiquidAfter),
+		"redeemFrom must lose exactly the redeemed liquid amount")
+	s.Require().Equal(redeemAmount, toBaseAfter.Sub(toBaseBefore),
+		"redeemTo base must increase by exactly the redeemed amount on the EOA cross-account path")
+	s.Require().Equal(redeemAmount, moduleBaseBefore.Sub(moduleBaseAfter),
+		"module base must decrease by exactly the redeemed amount")
+	s.Require().Equal(redeemAmount, supplyBefore.Sub(supplyAfter),
+		"liquid supply must decrease by exactly the redeemed amount via burn")
+	s.Require().Equal(moduleBaseBefore.Add(toBaseBefore), moduleBaseAfter.Add(toBaseAfter),
+		"base-denom conservation: module's debit must be fully accounted for by redeemTo's credit")
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 - keeper edge cases that strengthen integration coverage.
+//
+// These exercise specific x/liquidvesting branches that integration tests
+// only touch implicitly: liquidating exactly the locked total (account must
+// be preserved as an empty vesting account, not destroyed), re-minting a
+// liquid denom after a full redeem deletes the previous one, multi-denom
+// locked vesting schedules (only the targeted denom is affected),
+// liquidate-while-vesting-still-ongoing, liquidate-after-lockup-expired,
+// and the EOA self-target (from == to) bank-delta path that is otherwise
+// only verified through the Safe.
+// ---------------------------------------------------------------------------
+
+// TestLiquidateExactTotalLockedAccountPreserved verifies that liquidating
+// exactly the entire locked vesting principal:
+//  1. moves all base coins out of the from-account into the module;
+//  2. mints exactly that amount of a new aLIQUID denom into the to-account;
+//  3. PRESERVES the auth account as a ClawbackVestingAccount (it must NOT
+//     be replaced by a plain account or destroyed) with zeroed schedules;
+//  4. leaves the account in a state where any subsequent Liquidate fails
+//     because there is nothing locked left.
+//
+// This is the boundary case for x/liquidvesting/types.SubtractAmountFromPeriods
+// when subtrahend == total - the schedule is preserved but with empty amounts.
+func (s *PrecompileTestSuite) TestLiquidateExactTotalLockedAccountPreserved() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	toAccAddr := sdk.AccAddress(to.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	totalLocked := vestingAmount.AmountOf(utils.BaseDenom)
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, totalLocked.BigInt(),
+	})
+	s.Require().NoError(err, "liquidating exactly the locked total must succeed")
+
+	s.Require().Equal(sdkmath.ZeroInt(),
+		s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"from-account base must be fully drained")
+	s.Require().Equal(totalLocked,
+		s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"module must receive the full locked total")
+	s.Require().Equal(totalLocked,
+		s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidDenom).Amount,
+		"to-account must receive the full liquid mint")
+
+	acc := s.network.App.AccountKeeper.GetAccount(ctx, fromAccAddr)
+	s.Require().NotNil(acc, "auth account must still exist after full liquidation (account preservation)")
+	cba, ok := acc.(*vestingtypes.ClawbackVestingAccount)
+	s.Require().True(ok, "auth account type must be preserved as ClawbackVestingAccount, not downgraded")
+	s.Require().True(cba.OriginalVesting.AmountOf(utils.BaseDenom).IsZero(),
+		"OriginalVesting must be zero after liquidating the entire principal")
+	s.Require().True(cba.LockedCoins(ctx.BlockTime()).AmountOf(utils.BaseDenom).IsZero(),
+		"LockedCoins must be zero after liquidating the entire principal")
+
+	// A follow-up Liquidate must fail: nothing left locked, target denom
+	// is no longer present in GetLockedUpCoins.
+	contract2, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err = s.precompile.Liquidate(ctx, from, contract2, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err, "Liquidate against a fully-drained vesting account must fail")
+	s.Require().ErrorContains(err, "doesn't contain coin specified as liquidation target",
+		"empty-schedule error must propagate verbatim")
+}
+
+// TestLiquidateAfterFullRedeemCreatesNewTokenPair verifies that after a
+// liquid denom is fully redeemed (which deletes the keeper's Denom record
+// and toggles off the ERC20 conversion), the next Liquidate creates an
+// entirely NEW liquid denom (counter is monotonic) bound to a distinct
+// ERC20 contract address. This pins down two independent invariants:
+//   - the deleted denom is NOT recycled;
+//   - the keeper does NOT silently re-bind the same ERC20 address.
+func (s *PrecompileTestSuite) TestLiquidateAfterFullRedeemCreatesNewTokenPair() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	liquidateMethod := s.precompile.Methods[liquid.LiquidateMethod]
+	redeemMethod := s.precompile.Methods[liquid.RedeemMethod]
+
+	// First Liquidate: aLIQUID0, capture erc20 address #1.
+	c1, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	bz, err := s.precompile.Liquidate(ctx, from, c1, s.network.GetStateDB(), &liquidateMethod, []any{
+		from, from, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err)
+	out, err := liquidateMethod.Outputs.Unpack(bz)
+	s.Require().NoError(err)
+	erc20AddrFirst, ok := out[1].(common.Address)
+	s.Require().True(ok)
+	s.Require().NotEqual(common.Address{}, erc20AddrFirst, "first ERC20 address must be non-zero")
+
+	denomFirst := liquidtypes.DenomBaseNameFromID(0)
+	_, found := s.network.App.LiquidVestingKeeper.GetDenom(ctx, denomFirst)
+	s.Require().True(found, "first liquid denom must be registered after Liquidate")
+
+	// Full Redeem of aLIQUID0: keeper deletes the Denom and toggles off
+	// the ERC20 conversion.
+	c2, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, from, c2, s.network.GetStateDB(), &redeemMethod, []any{
+		from, from, denomFirst, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err)
+
+	_, found = s.network.App.LiquidVestingKeeper.GetDenom(ctx, denomFirst)
+	s.Require().False(found, "first liquid denom must be deleted after full redeem")
+
+	// Second Liquidate: counter went 0 -> 1 on the first call, so the
+	// new mint is aLIQUID1 (NOT aLIQUID0 - the deleted denom is not recycled).
+	c3, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	bz, err = s.precompile.Liquidate(ctx, from, c3, s.network.GetStateDB(), &liquidateMethod, []any{
+		from, from, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err)
+	out, err = liquidateMethod.Outputs.Unpack(bz)
+	s.Require().NoError(err)
+	erc20AddrSecond, ok := out[1].(common.Address)
+	s.Require().True(ok)
+
+	denomSecond := liquidtypes.DenomBaseNameFromID(1)
+	_, found = s.network.App.LiquidVestingKeeper.GetDenom(ctx, denomSecond)
+	s.Require().True(found, "second liquid denom (aLIQUID1) must be registered, not the recycled aLIQUID0")
+
+	s.Require().NotEqual(erc20AddrFirst, erc20AddrSecond,
+		"new liquid denom must bind to a fresh ERC20 contract address (no silent re-bind)")
+}
+
+// TestLiquidateMultiDenomLockedVesting verifies that Liquidate operates only
+// on the targeted base denom of the schedule and leaves any other locked
+// denoms untouched. We construct a vesting account with 3 lockup periods
+// each holding aISLM AND a sibling test denom; after liquidating aISLM, the
+// sibling denom must be unchanged in both bank balance and schedule.
+func (s *PrecompileTestSuite) TestLiquidateMultiDenomLockedVesting() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	toAccAddr := sdk.AccAddress(to.Bytes())
+
+	const siblingDenom = "atoken"
+
+	// Lockup schedule: 3 periods, each holding 1_000_000 aISLM + 100_000 atoken.
+	periodCoins := sdk.NewCoins(
+		sdk.NewInt64Coin(utils.BaseDenom, 1_000_000),
+		sdk.NewInt64Coin(siblingDenom, 100_000),
+	)
+	totalCoins := sdk.NewCoins(
+		sdk.NewInt64Coin(utils.BaseDenom, 3_000_000),
+		sdk.NewInt64Coin(siblingDenom, 300_000),
+	)
+	lockupPeriods := sdkvesting.Periods{
+		{Length: 100000, Amount: periodCoins},
+		{Length: 100000, Amount: periodCoins},
+		{Length: 100000, Amount: periodCoins},
+	}
+	vestingPeriods := sdkvesting.Periods{
+		{Length: 0, Amount: totalCoins}, // instantly vested - only lockup matters
+	}
+
+	funder := sdk.AccAddress(liquidtypes.ModuleName)
+	baseAccount := authtypes.NewBaseAccountWithAddress(fromAccAddr)
+	baseAccount.AccountNumber = s.network.App.AccountKeeper.NextAccountNumber(ctx)
+	startTime := ctx.BlockTime().Add(-10 * time.Second)
+	cba := vestingtypes.NewClawbackVestingAccount(
+		baseAccount, funder, totalCoins, startTime, lockupPeriods, vestingPeriods, nil,
+	)
+	s.Require().NoError(haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, fromAccAddr, totalCoins))
+	s.network.App.AccountKeeper.SetAccount(ctx, cba)
+
+	siblingBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, siblingDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err)
+
+	// Bank: aISLM moved out, atoken untouched.
+	s.Require().Equal(sdkmath.NewInt(2_000_000),
+		s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"aISLM bank balance must drop by exactly the liquidated amount")
+	s.Require().Equal(siblingBefore,
+		s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, siblingDenom).Amount,
+		"sibling denom bank balance must NOT change when liquidating aISLM")
+
+	// Schedule: each lockup period must still hold 100_000 atoken; aISLM
+	// per-period amount is reduced proportionally.
+	updated := s.network.App.AccountKeeper.GetAccount(ctx, fromAccAddr).(*vestingtypes.ClawbackVestingAccount)
+	s.Require().Equal(sdkmath.NewInt(300_000),
+		updated.LockupPeriods.TotalAmount().AmountOf(siblingDenom),
+		"sibling denom must remain fully locked across the schedule")
+	s.Require().Equal(sdkmath.NewInt(2_000_000),
+		updated.LockupPeriods.TotalAmount().AmountOf(utils.BaseDenom),
+		"aISLM lockup total must drop by exactly the liquidated amount")
+
+	// Liquid mint goes to the to-account in the freshly created denom.
+	s.Require().Equal(sdkmath.NewInt(1_000_000),
+		s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidtypes.DenomBaseNameFromID(0)).Amount,
+		"to-account must receive exactly 1_000_000 aLIQUID0")
+}
+
+// TestLiquidateVestingStillOngoing verifies the keeper rejects Liquidate
+// when the from-account still has non-vested coins (vestingPeriods has a
+// future-completing period). Without this guard, a user could pre-liquidate
+// not-yet-vested principal.
+func (s *PrecompileTestSuite) TestLiquidateVestingStillOngoing() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+
+	// Vesting still ongoing: a single vesting period of 100_000s starting
+	// 10s ago - GetVestingCoins(blockTime) returns the still-unvested coins.
+	periods := sdkvesting.Periods{
+		{Length: 100000, Amount: vestingAmount},
+	}
+	funder := sdk.AccAddress(liquidtypes.ModuleName)
+	baseAccount := authtypes.NewBaseAccountWithAddress(fromAccAddr)
+	baseAccount.AccountNumber = s.network.App.AccountKeeper.NextAccountNumber(ctx)
+	startTime := ctx.BlockTime().Add(-10 * time.Second)
+	cba := vestingtypes.NewClawbackVestingAccount(
+		baseAccount, funder, vestingAmount, startTime, periods, periods, nil,
+	)
+	s.Require().NoError(haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, fromAccAddr, vestingAmount))
+	s.network.App.AccountKeeper.SetAccount(ctx, cba)
+
+	// Sanity: the account does report non-zero vesting coins at this time.
+	s.Require().False(cba.GetVestingCoins(ctx.BlockTime()).IsZero(),
+		"fixture invariant: vesting must still be ongoing at block time")
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "has vesting ongoing periods",
+		"keeper must reject Liquidate while vesting is still ongoing")
+}
+
+// TestLiquidateLockupExpired verifies the keeper rejects Liquidate when the
+// account's lockup has fully elapsed (GetLockedUpCoins returns zero for the
+// target denom, so Find(amount.Denom) returns hasTargetDenom=false).
+func (s *PrecompileTestSuite) TestLiquidateLockupExpired() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+
+	// Lockup completed in the past: start time is far enough back that all
+	// 3 short lockup periods have already elapsed by block time.
+	lockupPeriods := sdkvesting.Periods{
+		{Length: 10, Amount: sdk.NewCoins(sdk.NewInt64Coin(utils.BaseDenom, 1_000_000))},
+		{Length: 10, Amount: sdk.NewCoins(sdk.NewInt64Coin(utils.BaseDenom, 1_000_000))},
+		{Length: 10, Amount: sdk.NewCoins(sdk.NewInt64Coin(utils.BaseDenom, 1_000_000))},
+	}
+	vestingPeriods := sdkvesting.Periods{
+		{Length: 0, Amount: vestingAmount},
+	}
+
+	funder := sdk.AccAddress(liquidtypes.ModuleName)
+	baseAccount := authtypes.NewBaseAccountWithAddress(fromAccAddr)
+	baseAccount.AccountNumber = s.network.App.AccountKeeper.NextAccountNumber(ctx)
+	startTime := ctx.BlockTime().Add(-1 * time.Hour) // 3600s ago, far past the 30s of total lockup
+	cba := vestingtypes.NewClawbackVestingAccount(
+		baseAccount, funder, vestingAmount, startTime, lockupPeriods, vestingPeriods, nil,
+	)
+	s.Require().NoError(haqqtestutil.FundAccount(ctx, s.network.App.BankKeeper, fromAccAddr, vestingAmount))
+	s.network.App.AccountKeeper.SetAccount(ctx, cba)
+
+	// Sanity: lockup is fully expired at block time.
+	s.Require().True(cba.GetLockedUpCoins(ctx.BlockTime()).IsZero(),
+		"fixture invariant: lockup must be fully expired at block time")
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "doesn't contain coin specified as liquidation target",
+		"keeper must reject Liquidate after lockup expiry (no target denom in locked coins)")
+}
+
+// TestLiquidateEOASameAddressBankDeltas exercises the EOA same-address
+// (from == to) Liquidate path with explicit bank-delta assertions. The
+// existing TestLiquidateSuccess uses different from/to; this fills the
+// matching invariant for the self-target case.
+func (s *PrecompileTestSuite) TestLiquidateEOASameAddressBankDeltas() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	addr := utiltx.GenerateAddress()
+	accAddr := sdk.AccAddress(addr.Bytes())
+	s.createClawbackVestingAccount(ctx, accAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	amount := sdkmath.NewInt(1_000_000)
+
+	baseBefore := s.network.App.BankKeeper.GetBalance(ctx, accAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, addr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, addr, contract, s.network.GetStateDB(), &method, []any{
+		addr, addr, amount.BigInt(),
+	})
+	s.Require().NoError(err)
+
+	baseAfter := s.network.App.BankKeeper.GetBalance(ctx, accAddr, utils.BaseDenom).Amount
+	moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	liquidAfter := s.network.App.BankKeeper.GetBalance(ctx, accAddr, liquidDenom).Amount
+
+	s.Require().Equal(amount, baseBefore.Sub(baseAfter),
+		"self-target Liquidate must debit the EOA base by exactly the liquidated amount")
+	s.Require().Equal(amount, liquidAfter,
+		"self-target Liquidate must credit the EOA with exactly the liquidated amount of aLIQUID0")
+	s.Require().Equal(amount, moduleBaseAfter.Sub(moduleBaseBefore),
+		"self-target Liquidate must credit the module by exactly the liquidated amount")
+	s.Require().Equal(baseBefore.Add(moduleBaseBefore), baseAfter.Add(moduleBaseAfter),
+		"base-denom conservation must hold for self-target EOA Liquidate")
+}
+
+// ---------------------------------------------------------------------------
+// Authz edge cases: expired grants must be treated as missing, and the
+// origin/sender invariant must be enforced uniformly across both EOA-caller
+// and contract-caller paths so a contract caller cannot use authz to act on
+// behalf of arbitrary senders that don't match origin.
+// ---------------------------------------------------------------------------
+
+// TestLiquidateAuthzExpired verifies the precompile treats an expired authz
+// grant the same as a missing one. We save a grant with a 1-second expiration
+// (NewGrant requires expiration > current block time), then advance the
+// in-memory ctx block time past it before calling Liquidate. GetAuthorization
+// must return nil and the precompile must surface the standard
+// "does not exist or is expired" error.
+func (s *PrecompileTestSuite) TestLiquidateAuthzExpired() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress()
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+	to := s.keyring.GetAddr(1)
+
+	s.createClawbackVestingAccount(ctx, originAccAddr)
+
+	// Grant with a 1-second expiration window starting from the current
+	// block time. NewGrant rejects expirations that are already in the
+	// past, so we cannot save an "already expired" grant directly.
+	expiration := ctx.BlockTime().Add(time.Second)
+	err := s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	// Sanity: at this block time the grant is still live.
+	auth, _ := s.network.App.AuthzKeeper.GetAuthorization(
+		ctx, callerAccAddr, originAccAddr, sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{}),
+	)
+	s.Require().NotNil(auth, "fixture invariant: grant must be live before time advance")
+
+	// Advance the in-memory block time past the expiration. The next
+	// GetAuthorization must report it as expired.
+	ctx = ctx.WithBlockTime(expiration.Add(time.Second))
+	auth, _ = s.network.App.AuthzKeeper.GetAuthorization(
+		ctx, callerAccAddr, originAccAddr, sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{}),
+	)
+	s.Require().Nil(auth, "fixture invariant: grant must be expired after time advance")
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Liquidate(ctx, originAddr, contract, s.network.GetStateDB(), &method, []any{
+		originAddr, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "does not exist or is expired",
+		"expired authz grant must produce the same error as a missing grant")
+}
+
+// TestRedeemAuthzExpired verifies the same expired-grant invariant for the
+// Redeem method. Symmetric to TestLiquidateAuthzExpired - both methods share
+// the same authz lookup path, so both must observe the time-based expiry.
+func (s *PrecompileTestSuite) TestRedeemAuthzExpired() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress()
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+
+	expiration := ctx.BlockTime().Add(time.Second)
+	err := s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgRedeem{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	ctx = ctx.WithBlockTime(expiration.Add(time.Second))
+
+	method := s.precompile.Methods[liquid.RedeemMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, originAddr, contract, s.network.GetStateDB(), &method, []any{
+		originAddr, originAddr, liquidtypes.DenomBaseNameFromID(0), big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "does not exist or is expired",
+		"expired Redeem authz grant must produce the same error as a missing grant")
+}
+
+// TestLiquidateThirdPartySenderViaContract pins down the origin/sender
+// invariant on the contract-caller path: when the caller is a contract, the
+// ABI from-field (sender) must equal either the caller (contract acting on
+// its own behalf) OR the tx origin (contract acting via authz). A third
+// party that is neither must be rejected BEFORE the authz lookup.
+//
+// Without this guard, a malicious contract could ask the precompile to
+// execute MsgLiquidate.From = victim using its own authz from origin -
+// trivially defeating the per-granter authorization model.
+func (s *PrecompileTestSuite) TestLiquidateThirdPartySenderViaContract() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress() // contract caller, != origin
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+	thirdParty := utiltx.GenerateAddress() // ABI from-field, != caller AND != origin
+	to := s.keyring.GetAddr(1)
+
+	s.createClawbackVestingAccount(ctx, originAccAddr)
+
+	// Save a valid authz grant from origin to caller. The check we want
+	// to validate runs BEFORE the authz lookup, so the grant being
+	// present just makes it an even more aggressive attempt.
+	expiration := time.Now().Add(time.Hour)
+	err := s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Liquidate(ctx, originAddr, contract, s.network.GetStateDB(), &method, []any{
+		thirdParty, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "origin address",
+		"sender (msg.from) must equal caller or origin even on the contract-caller path")
+}
+
+// TestRedeemThirdPartySenderViaContract is the symmetric test for Redeem:
+// the same origin/sender check exists in Redeem and must be exercised on
+// the contract-caller path.
+func (s *PrecompileTestSuite) TestRedeemThirdPartySenderViaContract() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress()
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+	thirdParty := utiltx.GenerateAddress()
+
+	expiration := time.Now().Add(time.Hour)
+	err := s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgRedeem{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	method := s.precompile.Methods[liquid.RedeemMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, originAddr, contract, s.network.GetStateDB(), &method, []any{
+		thirdParty, thirdParty, liquidtypes.DenomBaseNameFromID(0), big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "origin address",
+		"sender (msg.from) must equal caller or origin even on the contract-caller path (Redeem)")
+}
+
+// ---------------------------------------------------------------------------
+// Keeper-side error pass-through: invariant that liquidvesting keeper errors
+// are surfaced verbatim through the precompile, no side effects leak into
+// bank, and the precompile does not panic / partially commit.
+//
+// These tests exercise the EOA path on purpose: the precompile's RunAtomic
+// rollback is bypassed when methods are invoked directly (no Run dispatcher),
+// so the keeper itself must short-circuit BEFORE any state mutation.
+// Each test asserts (a) the error contains the expected SDK message and
+// (b) bank state on the touched accounts is unchanged.
+// ---------------------------------------------------------------------------
+
+// TestLiquidateOnRegularAccount verifies the keeper rejects Liquidate with
+// "is regular nothing to liquidate" when the from-account is not a
+// ClawbackVestingAccount, and that no state mutation occurs.
+func (s *PrecompileTestSuite) TestLiquidateOnRegularAccount() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := s.keyring.GetAddr(0)
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+
+	// Sanity: the keyring account exists but is NOT a vesting account.
+	acc := s.network.App.AccountKeeper.GetAccount(ctx, fromAccAddr)
+	s.Require().NotNil(acc)
+	_, isVesting := acc.(*vestingtypes.ClawbackVestingAccount)
+	s.Require().False(isVesting, "test fixture must be a plain account, not a vesting account")
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "is regular nothing to liquidate",
+		"keeper error must be propagated verbatim through the precompile")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"failed Liquidate must not touch the from-account base balance")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"failed Liquidate must not credit the liquid vesting module")
+}
+
+// TestLiquidateModuleDisabled verifies the keeper short-circuits with
+// "liquid vesting module is disabled" when params.EnableLiquidVesting is
+// false, before touching any accounts.
+func (s *PrecompileTestSuite) TestLiquidateModuleDisabled() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	// Disable the module via params, refresh ctx so Liquidate observes it.
+	s.network.App.LiquidVestingKeeper.SetLiquidVestingEnabled(ctx, false)
+	ctx = s.network.GetContext()
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "liquid vesting module is disabled",
+		"disabled-module guard must short-circuit Liquidate at the keeper level")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"Liquidate against a disabled module must not move funds")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"Liquidate against a disabled module must not credit the module")
+}
+
+// TestLiquidateBelowMinimum verifies the keeper rejects Liquidate when the
+// amount is strictly below MinimumLiquidationAmount (set to 1_000_000 in the
+// test fixture). 999_999 must trip the guard; 1_000_000 must succeed (the
+// boundary success case is covered by other tests).
+func (s *PrecompileTestSuite) TestLiquidateBelowMinimum() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(999_999),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "unable to liquidate amount lesser than",
+		"sub-minimum amount must be rejected by the keeper")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"sub-minimum Liquidate must not move funds")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"sub-minimum Liquidate must not credit the module")
+}
+
+// TestLiquidateExceedsLocked verifies the keeper rejects Liquidate when the
+// requested amount exceeds the account's currently-locked balance for the
+// target denom. Vesting fixture has 3_000_000 locked; we ask for 4_000_000.
+func (s *PrecompileTestSuite) TestLiquidateExceedsLocked() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, big.NewInt(4_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "doesn't have sufficient amount of target coin for liquidation",
+		"over-locked Liquidate must be rejected by the keeper")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"over-locked Liquidate must not move funds")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"over-locked Liquidate must not credit the module")
+}
+
+// TestRedeemUnknownDenom verifies the keeper rejects Redeem when the supplied
+// denom has no corresponding x/liquidvesting Denom record.
+func (s *PrecompileTestSuite) TestRedeemUnknownDenom() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := s.keyring.GetAddr(0)
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+
+	// Use a denom id far above any aLIQUID we could have created in this
+	// test (counter starts at 0); guarantees GetDenom returns not-found.
+	unknownDenom := liquidtypes.DenomBaseNameFromID(9999)
+
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.RedeemMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Redeem(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, from, unknownDenom, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "does not exist",
+		"unknown liquid denom must be rejected at the keeper denom lookup")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"failed Redeem must not change the from-account base balance")
+}
+
+// TestRedeemInsufficientLiquidBalance verifies the keeper rejects Redeem when
+// the from-account holds fewer liquid tokens than requested. We mint
+// 1_000_000 via Liquidate then attempt to redeem 2_000_000.
+func (s *PrecompileTestSuite) TestRedeemInsufficientLiquidBalance() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	liquidateMethod := s.precompile.Methods[liquid.LiquidateMethod]
+	liqContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, liqContract, s.network.GetStateDB(), &liquidateMethod, []any{
+		from, from, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	fromLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	supplyBefore := s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount
+
+	redeemMethod := s.precompile.Methods[liquid.RedeemMethod]
+	redContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, from, redContract, s.network.GetStateDB(), &redeemMethod, []any{
+		from, from, liquidDenom, big.NewInt(2_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "insufficient balance",
+		"over-balance Redeem must be rejected by the keeper insufficient-balance check")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount,
+		"failed Redeem must not change the from base balance")
+	s.Require().Equal(fromLiquidBefore, s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, liquidDenom).Amount,
+		"failed Redeem must not burn any liquid tokens")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"failed Redeem must not move base from the module")
+	s.Require().Equal(supplyBefore, s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount,
+		"failed Redeem must not change liquid supply")
+}
+
+// TestLiquidateEOAvsContractParity verifies that a Liquidate call produces the
+// SAME post-call bank state regardless of whether the precompile is invoked
+// directly by the EOA holder (caller == origin, mirror skipped) or from a
+// contract caller via authz (caller != origin, mirror MUST fire to keep
+// StateDB and bank consistent). If the mirror were silently broken on the
+// contract path, or wrongly enabled on the EOA path, the two scenarios would
+// diverge and this test would catch it.
+//
+// Note: each scenario is run in a freshly-set-up network, so addresses
+// generated by utiltx are different across runs - we compare deltas, not
+// absolute balances.
+func (s *PrecompileTestSuite) TestLiquidateEOAvsContractParity() {
+	type bankDelta struct {
+		fromBaseDebit  sdkmath.Int
+		toLiquidCredit sdkmath.Int
+		moduleBaseAdd  sdkmath.Int
+		liquidSupply   sdkmath.Int
+	}
+
+	amount := sdkmath.NewInt(1_000_000)
+	liquidDenom := liquidtypes.DenomBaseNameFromID(0)
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+
+	// runScenario performs a Liquidate from a fresh vesting account into a
+	// fresh receiver and returns the observed bank deltas. The caller flag
+	// flips between caller == origin (EOA path, no authz) and caller !=
+	// origin (contract path, authz required).
+	runScenario := func(callerIsOrigin bool) bankDelta {
+		s.SetupTest()
+		ctx := s.network.GetContext()
+
+		fromEvmAddr := utiltx.GenerateAddress()
+		fromAccAddr := sdk.AccAddress(fromEvmAddr.Bytes())
+		toEvmAddr := utiltx.GenerateAddress()
+		toAccAddr := sdk.AccAddress(toEvmAddr.Bytes())
+
+		s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+		callerEvmAddr := fromEvmAddr
+		if !callerIsOrigin {
+			callerEvmAddr = utiltx.GenerateAddress()
+			callerAccAddr := sdk.AccAddress(callerEvmAddr.Bytes())
+			expiration := time.Now().Add(time.Hour)
+			err := s.network.App.AuthzKeeper.SaveGrant(
+				ctx,
+				callerAccAddr,
+				fromAccAddr,
+				sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{})),
+				&expiration,
+			)
+			s.Require().NoError(err)
+		}
+
+		fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+		toLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidDenom).Amount
+		moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+		method := s.precompile.Methods[liquid.LiquidateMethod]
+		contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerEvmAddr, s.precompile, 500000)
+		_, err := s.precompile.Liquidate(ctx, fromEvmAddr, contract, s.network.GetStateDB(), &method, []any{
+			fromEvmAddr, toEvmAddr, amount.BigInt(),
+		})
+		s.Require().NoError(err)
+
+		fromBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+		toLiquidAfter := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, liquidDenom).Amount
+		moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+		return bankDelta{
+			fromBaseDebit:  fromBaseBefore.Sub(fromBaseAfter),
+			toLiquidCredit: toLiquidAfter.Sub(toLiquidBefore),
+			moduleBaseAdd:  moduleBaseAfter.Sub(moduleBaseBefore),
+			liquidSupply:   s.network.App.BankKeeper.GetSupply(ctx, liquidDenom).Amount,
+		}
+	}
+
+	eoa := runScenario(true)
+	contract := runScenario(false)
+
+	s.Require().Equal(amount, eoa.fromBaseDebit, "EOA scenario: from must be debited by exactly the liquidated amount")
+	s.Require().Equal(amount, contract.fromBaseDebit, "contract scenario: from must be debited by exactly the liquidated amount")
+	s.Require().Equal(eoa.fromBaseDebit, contract.fromBaseDebit,
+		"from base debit must be identical between EOA and contract caller paths (mirror parity)")
+	s.Require().Equal(eoa.toLiquidCredit, contract.toLiquidCredit,
+		"to liquid credit must be identical between EOA and contract caller paths")
+	s.Require().Equal(eoa.moduleBaseAdd, contract.moduleBaseAdd,
+		"module base credit must be identical between EOA and contract caller paths")
+	s.Require().Equal(eoa.liquidSupply, contract.liquidSupply,
+		"final liquid supply must be identical between EOA and contract caller paths")
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3 - defensive / boundary tests for user-controlled accounts
+// (EOA + smart-contract callers). Module-account-as-from is intentionally
+// out of scope.
+//
+// Each test exercises a single defensive guard and asserts:
+//   (a) the precompile returns the expected error class without panicking;
+//   (b) bank state on the touched accounts is unchanged on failure paths.
+// ---------------------------------------------------------------------------
+
+// TestLiquidateAtExactMinimumAmount pins the boundary of the
+// MinimumLiquidationAmount param: keeper rejects via amount.IsLT(min), so an
+// amount EQUAL to the minimum must succeed (boundary is inclusive on the low
+// side). If a future refactor flips the comparison to amount.LTE, this test
+// will catch the regression by failing the success path.
+func (s *PrecompileTestSuite) TestLiquidateAtExactMinimumAmount() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	to := s.keyring.GetAddr(1)
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	// Sanity: the configured param must equal the amount we are about to
+	// liquidate; otherwise the boundary assertion below loses meaning.
+	min := s.network.App.LiquidVestingKeeper.GetParams(ctx).MinimumLiquidationAmount
+	s.Require().Equal(sdkmath.NewInt(1_000_000), min,
+		"test setup must pin MinimumLiquidationAmount to 1_000_000")
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, to, min.BigInt(),
+	})
+	s.Require().NoError(err, "amount equal to MinimumLiquidationAmount must be accepted (boundary inclusive)")
+
+	fromBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	moduleBaseAfter := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+	s.Require().Equal(min, fromBaseBefore.Sub(fromBaseAfter),
+		"from must be debited exactly the minimum amount")
+	s.Require().Equal(min, moduleBaseAfter.Sub(moduleBaseBefore),
+		"module must be credited exactly the minimum amount")
+}
+
+// TestLiquidateFromZeroAddress verifies the keeper rejects Liquidate when
+// the from-account does not exist on chain. A fresh setup has no account at
+// 0x0, so accountKeeper.GetAccount returns nil and the keeper aborts with
+// "account does not exist". No bank movement may occur.
+//
+// NOTE: origin must match sender (the ABI from-field), so origin is also
+// set to 0x0 here. This is impossible in production (no signed EVM tx can
+// have origin == 0x0) but the precompile entry-point itself does not - and
+// should not - enforce that, so the keeper guard is the actual defence.
+func (s *PrecompileTestSuite) TestLiquidateFromZeroAddress() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	zeroAddr := common.Address{}
+	zeroAccAddr := sdk.AccAddress(zeroAddr.Bytes())
+	to := s.keyring.GetAddr(1)
+	toAccAddr := sdk.AccAddress(to.Bytes())
+
+	// Sanity: there must be no account at 0x0 in a fresh network.
+	s.Require().Nil(s.network.App.AccountKeeper.GetAccount(ctx, zeroAccAddr),
+		"fresh network must not have an account at the zero address")
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	zeroBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, utils.BaseDenom).Amount
+	toBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, zeroAddr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, zeroAddr, contract, s.network.GetStateDB(), &method, []any{
+		zeroAddr, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "does not exist",
+		"non-existent from-account must be rejected with an account-lookup error")
+
+	s.Require().Equal(zeroBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, utils.BaseDenom).Amount,
+		"failed Liquidate must not touch the zero-address bank balance")
+	s.Require().Equal(toBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, toAccAddr, utils.BaseDenom).Amount,
+		"failed Liquidate must not touch the receiver bank balance")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"failed Liquidate must not credit the module")
+}
+
+// TestRedeemFromZeroAddress is the symmetric defence for Redeem: a non-
+// existent from-account is rejected by the keeper before any bank movement.
+func (s *PrecompileTestSuite) TestRedeemFromZeroAddress() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	zeroAddr := common.Address{}
+	zeroAccAddr := sdk.AccAddress(zeroAddr.Bytes())
+
+	s.Require().Nil(s.network.App.AccountKeeper.GetAccount(ctx, zeroAccAddr),
+		"fresh network must not have an account at the zero address")
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	zeroBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.RedeemMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, zeroAddr, s.precompile, 500000)
+	_, err := s.precompile.Redeem(ctx, zeroAddr, contract, s.network.GetStateDB(), &method, []any{
+		zeroAddr, zeroAddr, liquidtypes.DenomBaseNameFromID(0), big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "does not exist",
+		"non-existent from-account must be rejected with an account-lookup error")
+
+	s.Require().Equal(zeroBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, utils.BaseDenom).Amount,
+		"failed Redeem must not touch the zero-address bank balance")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"failed Redeem must not touch the module bank balance")
+}
+
+// TestLiquidateAuthzWrongMsgType verifies that authz scope is enforced by
+// message-type URL: a grant for MsgRedeem cannot authorize a Liquidate call
+// from the same caller. The precompile must reject with
+// ErrAuthzDoesNotExistOrExpired (not silently fall through), and no bank
+// movement may occur.
+func (s *PrecompileTestSuite) TestLiquidateAuthzWrongMsgType() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress()
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+	to := s.keyring.GetAddr(1)
+
+	s.createClawbackVestingAccount(ctx, originAccAddr)
+
+	// Wrong-type grant: MsgRedeem cannot authorize MsgLiquidate.
+	expiration := time.Now().Add(time.Hour)
+	err := s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgRedeem{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Liquidate(ctx, originAddr, contract, s.network.GetStateDB(), &method, []any{
+		originAddr, to, big.NewInt(1_000_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "authorization",
+		"authz grant scoped to a different msg type must not authorize Liquidate")
+
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, utils.BaseDenom).Amount,
+		"rejected wrong-type-grant Liquidate must not move from-base")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"rejected wrong-type-grant Liquidate must not credit the module")
+}
+
+// TestRedeemAuthzWrongMsgType is the symmetric authz-scope defence for
+// Redeem: a grant for MsgLiquidate cannot authorize a Redeem call from the
+// same caller. Setup needs an actual liquid denom in flight, so we first do
+// a self-Liquidate via the EOA path (no authz needed) to mint aLIQUID0,
+// then attempt the Redeem via the contract path with the wrong-type grant.
+func (s *PrecompileTestSuite) TestRedeemAuthzWrongMsgType() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	originAddr := utiltx.GenerateAddress()
+	originAccAddr := sdk.AccAddress(originAddr.Bytes())
+	callerAddr := utiltx.GenerateAddress()
+	callerAccAddr := sdk.AccAddress(callerAddr.Bytes())
+
+	s.createClawbackVestingAccount(ctx, originAccAddr)
+
+	// Step A: EOA self-Liquidate to obtain a real aLIQUID0 balance on origin.
+	liqMethod := s.precompile.Methods[liquid.LiquidateMethod]
+	liqContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, originAddr, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, originAddr, liqContract, s.network.GetStateDB(), &liqMethod, []any{
+		originAddr, originAddr, big.NewInt(1_000_000),
+	})
+	s.Require().NoError(err, "setup self-Liquidate must succeed to mint aLIQUID0")
+
+	// Step B: wrong-type grant - MsgLiquidate cannot authorize MsgRedeem.
+	expiration := time.Now().Add(time.Hour)
+	err = s.network.App.AuthzKeeper.SaveGrant(
+		ctx, callerAccAddr, originAccAddr,
+		sdkauthz.NewGenericAuthorization(sdk.MsgTypeURL(&liquidtypes.MsgLiquidate{})),
+		&expiration,
+	)
+	s.Require().NoError(err)
+
+	denom := liquidtypes.DenomBaseNameFromID(0)
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+	fromLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, denom).Amount
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, utils.BaseDenom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	method := s.precompile.Methods[liquid.RedeemMethod]
+	redeemContract, ctx := testutil.NewPrecompileContract(s.T(), ctx, callerAddr, s.precompile, 500000)
+	_, err = s.precompile.Redeem(ctx, originAddr, redeemContract, s.network.GetStateDB(), &method, []any{
+		originAddr, originAddr, denom, big.NewInt(500_000),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "authorization",
+		"authz grant scoped to a different msg type must not authorize Redeem")
+
+	s.Require().Equal(fromLiquidBefore, s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, denom).Amount,
+		"rejected wrong-type-grant Redeem must not burn liquid tokens")
+	s.Require().Equal(fromBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, originAccAddr, utils.BaseDenom).Amount,
+		"rejected wrong-type-grant Redeem must not return base coins to from")
+	s.Require().Equal(moduleBaseBefore, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount,
+		"rejected wrong-type-grant Redeem must not move the module's base balance")
+}
+
+// TestLiquidateToZeroAddress is a PIN test: it documents the current
+// behaviour of Liquidate when the receiver of the freshly-minted aLIQUID*
+// is the zero address (0x0). The precompile itself does not validate the
+// receiver address, so the actual fate is decided by the bank module's
+// SendCoinsFromModuleToAccount call inside the keeper.
+//
+// Expected current behaviour: the call SUCCEEDS - 0x0 is a normal,
+// non-blocked bank holder, the aLIQUID0 supply is created on it, and from
+// is correctly debited the base amount. The minted tokens are functionally
+// unrecoverable (no key controls 0x0), but that is a caller-side concern
+// and not a precompile-level guard.
+//
+// If this test ever starts FAILING, that means new validation has been
+// added (e.g. blocked-address list, explicit zero check) - the change must
+// be reviewed deliberately rather than silently accepted, hence pinning
+// here.
+func (s *PrecompileTestSuite) TestLiquidateToZeroAddress() {
+	s.SetupTest()
+	ctx := s.network.GetContext()
+
+	from := utiltx.GenerateAddress()
+	fromAccAddr := sdk.AccAddress(from.Bytes())
+	zeroAddr := common.Address{}
+	zeroAccAddr := sdk.AccAddress(zeroAddr.Bytes())
+	s.createClawbackVestingAccount(ctx, fromAccAddr)
+
+	denom := liquidtypes.DenomBaseNameFromID(0)
+	moduleAddr := authtypes.NewModuleAddress(liquidtypes.ModuleName)
+
+	fromBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount
+	zeroLiquidBefore := s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, denom).Amount
+	moduleBaseBefore := s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount
+
+	amount := sdkmath.NewInt(1_000_000)
+	method := s.precompile.Methods[liquid.LiquidateMethod]
+	contract, ctx := testutil.NewPrecompileContract(s.T(), ctx, from, s.precompile, 500000)
+	_, err := s.precompile.Liquidate(ctx, from, contract, s.network.GetStateDB(), &method, []any{
+		from, zeroAddr, amount.BigInt(),
+	})
+	s.Require().NoError(err,
+		"PIN: Liquidate to 0x0 currently succeeds; if this fails a new receiver-side guard was added and must be reviewed")
+
+	s.Require().Equal(amount, fromBaseBefore.Sub(s.network.App.BankKeeper.GetBalance(ctx, fromAccAddr, utils.BaseDenom).Amount),
+		"PIN: from must be debited exactly the liquidated amount")
+	s.Require().Equal(amount, s.network.App.BankKeeper.GetBalance(ctx, zeroAccAddr, denom).Amount.Sub(zeroLiquidBefore),
+		"PIN: zero-address must receive the freshly-minted liquid supply")
+	s.Require().Equal(amount, s.network.App.BankKeeper.GetBalance(ctx, moduleAddr, utils.BaseDenom).Amount.Sub(moduleBaseBefore),
+		"PIN: module must be credited exactly the liquidated base amount")
+	s.Require().Equal(amount, s.network.App.BankKeeper.GetSupply(ctx, denom).Amount,
+		"PIN: aLIQUID0 total supply must equal the minted amount")
+}

--- a/precompiles/liquid/types.go
+++ b/precompiles/liquid/types.go
@@ -13,6 +13,22 @@ import (
 	liquidtypes "github.com/haqq-network/haqq/x/liquidvesting/types"
 )
 
+// EventLiquidate defines the event data for the Liquidate event.
+type EventLiquidate struct {
+	Sender        common.Address
+	Receiver      common.Address
+	Amount        *big.Int
+	Erc20Contract common.Address
+}
+
+// EventRedeem defines the event data for the Redeem event.
+type EventRedeem struct {
+	Sender   common.Address
+	Receiver common.Address
+	Denom    string
+	Amount   *big.Int
+}
+
 // NewLiquidateMsg builds a MsgLiquidate from ABI arguments.
 // Expected args: [from common.Address, to common.Address, amount *big.Int].
 func NewLiquidateMsg(args []interface{}) (*liquidtypes.MsgLiquidate, common.Address, common.Address, error) {

--- a/x/liquidvesting/keeper/keeper.go
+++ b/x/liquidvesting/keeper/keeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,6 +25,10 @@ var _ Keeper = (*BaseKeeper)(nil)
 type Keeper interface {
 	Liquidate(ctx sdk.Context, fromAddress, toAddress sdk.AccAddress, amount sdk.Coin) (sdk.Coin, string, error)
 	Redeem(ctx sdk.Context, fromAddress, toAddress sdk.AccAddress, amount sdk.Coin) error
+
+	// Bank balance helpers used by the precompile to mirror SDK bank deltas into
+	// the EVM StateDB journal when the precompile is invoked from a contract.
+	BaseDenomBankBalance(ctx sdk.Context, addr sdk.AccAddress) sdkmath.Int
 
 	// Params methods
 	GetParams(ctx sdk.Context) types.Params
@@ -83,6 +88,15 @@ func NewKeeper(
 		erc20Keeper:   erc20,
 		vestingKeeper: vk,
 	}
+}
+
+// BaseDenomBankBalance returns the bank balance of aISLM for addr (utils.BaseDenom).
+// On Haqq, EvmDenom defaults to utils.BaseDenom; this is the balance the EVM keeper
+// reconciles for native EVM accounts on tx commit, so the liquid precompile uses it
+// to compute the bank delta produced by Liquidate/Redeem keeper calls and mirror
+// that delta into the EVM StateDB journal when the caller is a contract.
+func (k BaseKeeper) BaseDenomBankBalance(ctx sdk.Context, addr sdk.AccAddress) sdkmath.Int {
+	return k.bankKeeper.GetBalance(ctx, addr, utils.BaseDenom).Amount
 }
 
 // Liquidate liquidates specified amount of token locked in vesting into liquid token


### PR DESCRIPTION
## Description

Fixed a Liquid Vesting precompile bug when called from a contract: base-denom moves in the bank were not aligned with the EVM journal, and self-redeem could double-credit; the precompile now mirrors bank deltas with per-address deduplication. BaseDenomBankBalance in the keeper uses a correct single-denom balance read. Added unit tests (mirror/parity, keeper errors, authz, tier 2/3) and a Gnosis Safe integration scenario covering multi-step liquidate/redeem.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
